### PR TITLE
Add POTACAT Speakermic integration

### DIFF
--- a/renderer/remote.css
+++ b/renderer/remote.css
@@ -3320,3 +3320,37 @@ html, body {
 .dir-card-freq { font-family: monospace; }
 
 .dir-empty { text-align: center; color: var(--text-dim); padding: 40px 0; font-size: 14px; }
+
+/* ── Speakermic Button ── */
+.bb-mic-btn {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1px;
+  font-size: 11px;
+  color: var(--text-dim);
+  background: #1a1a2e;
+  border: 2px solid #2a2a4a;
+  transition: border-color 0.3s, color 0.3s;
+}
+.bb-mic-btn #speakermic-icon { font-size: 18px; line-height: 1; }
+.bb-mic-btn #speakermic-label { font-size: 10px; }
+.bb-mic-btn.mic-connected {
+  border-color: var(--pota);
+  color: var(--pota);
+}
+.bb-mic-btn.mic-connected #speakermic-label { font-size: 9px; }
+.bb-mic-btn.mic-connecting {
+  border-color: #4a9eff;
+  animation: mic-pulse 1.5s infinite;
+}
+@keyframes mic-pulse {
+  0%, 100% { border-color: #4a9eff; }
+  50% { border-color: #1a3a6e; }
+}
+.bb-mic-btn.mic-error {
+  border-color: var(--accent);
+  color: var(--accent);
+}

--- a/renderer/remote.html
+++ b/renderer/remote.html
@@ -204,6 +204,50 @@
           <select id="rc-audio-output" class="so-select" style="flex:1;font-size:12px;"></select>
         </div>
         <button type="button" id="rc-audio-refresh" class="ft8-filter-btn" style="margin:4px 0 8px;">Refresh Devices</button>
+
+        <!-- Speakermic -->
+        <div class="so-section-label">Speakermic</div>
+        <div class="so-row">
+          <label class="so-label">Enable</label>
+          <div class="so-controls">
+            <button type="button" class="rc-btn rc-toggle" id="so-speakermic-enable">Off</button>
+            <span style="font-size:11px;color:var(--text-dim);margin-left:6px;">Shows Mic in toolbar</span>
+          </div>
+        </div>
+        <div id="so-speakermic-settings" style="display:none;">
+          <div class="so-row">
+            <label class="so-label">Device</label>
+            <div class="so-controls">
+              <button type="button" class="rc-btn" id="so-speakermic-connect" style="min-width:90px;">Connect</button>
+              <span id="so-speakermic-status" style="font-size:12px;color:var(--text-dim);margin-left:6px;">Not connected</span>
+            </div>
+          </div>
+          <div class="so-row" id="so-speakermic-details" style="display:none;">
+            <label class="so-label">Battery</label>
+            <div class="so-controls">
+              <div style="display:flex;align-items:center;gap:6px;">
+                <div style="width:80px;height:10px;background:#2a2a4a;border-radius:4px;overflow:hidden;">
+                  <div id="so-speakermic-batt-fill" style="height:100%;width:100%;background:var(--pota);border-radius:4px;transition:width 0.5s;"></div>
+                </div>
+                <span id="so-speakermic-batt-pct" style="font-size:12px;color:var(--text-dim);">--%</span>
+              </div>
+            </div>
+          </div>
+          <div class="so-row" id="so-speakermic-vol-row" style="display:none;">
+            <label class="so-label">Speaker Vol</label>
+            <div class="so-controls">
+              <input type="range" id="so-speakermic-vol" min="0" max="100" value="70" style="width:100px;">
+              <span id="so-speakermic-vol-label" style="font-size:12px;color:var(--text-dim);margin-left:4px;min-width:30px;">70%</span>
+            </div>
+          </div>
+          <div class="so-row">
+            <label class="so-label">Auto-Reconnect</label>
+            <div class="so-controls">
+              <button type="button" class="rc-btn rc-toggle active" id="so-speakermic-reconnect">On</button>
+            </div>
+          </div>
+        </div>
+
         <div class="so-section-label">Display</div>
         <label class="so-label" style="display:flex;align-items:center;gap:8px;padding:4px 0;">
           <input type="checkbox" id="echo-show-meter"> Show S-Meter / SWR
@@ -924,6 +968,10 @@
           <button id="vol-boost-btn" type="button" class="bb-square-btn hidden" title="Volume Boost">Vol 1x</button>
         </div>
         <button type="button" id="scan-btn" class="bb-round-btn" title="Scan spots">Scan</button>
+        <button type="button" id="speakermic-btn" class="bb-round-btn bb-mic-btn hidden" title="Connect Speakermic">
+          <span id="speakermic-icon">&#x1F399;</span>
+          <span id="speakermic-label">Mic</span>
+        </button>
         <button id="ptt-btn" type="button" class="ptt-button">PTT</button>
         <button id="estop-btn" type="button" class="bb-halt-btn">HALT</button>
       </div>

--- a/renderer/remote.js
+++ b/renderer/remote.js
@@ -2113,6 +2113,7 @@
     muteRxAudio(true);
     // Unmute mic track so audio reaches radio modulator
     if (localAudioStream) localAudioStream.getAudioTracks().forEach(t => { t.enabled = true; });
+    if (typeof smConnected !== 'undefined' && smConnected && smMicTrack) smMicTrack.enabled = true;
     if (ws && ws.readyState === WebSocket.OPEN) {
       ws.send(JSON.stringify({ type: 'ptt', state: true }));
     }
@@ -2126,6 +2127,7 @@
     muteRxAudio(false);
     // Re-mute mic track to prevent VOX/feedback TX cycling
     if (localAudioStream) localAudioStream.getAudioTracks().forEach(t => { t.enabled = false; });
+    if (typeof smConnected !== 'undefined' && smConnected && smMicTrack) smMicTrack.enabled = false;
     if (ws && ws.readyState === WebSocket.OPEN) {
       ws.send(JSON.stringify({ type: 'ptt', state: false }));
     }
@@ -2992,11 +2994,13 @@
   function showAudioControls() {
     audioConnectBtn.classList.add('hidden');
     bbControls.classList.remove('hidden');
+    if (typeof smEnabled !== 'undefined' && smEnabled) document.getElementById('speakermic-btn').classList.remove('hidden');
   }
   function showConnectPrompt() {
     audioConnectBtn.textContent = 'Tap to Connect Audio';
     audioConnectBtn.classList.remove('hidden');
     bbControls.classList.add('hidden');
+    document.getElementById('speakermic-btn').classList.add('hidden');
   }
 
   audioConnectBtn.addEventListener('click', async () => {
@@ -3105,6 +3109,7 @@
           remoteAudio.muted = false;
           remoteAudio.play().catch(() => {});
         }
+        if (typeof smConnected !== 'undefined' && smConnected) smSetupRxBridge(event.streams[0]);
       };
       pc.onicecandidate = (event) => {
         if (event.candidate && ws && ws.readyState === WebSocket.OPEN) {
@@ -3138,6 +3143,7 @@
 
   function stopAudio() {
     if (ssbPlayingIdx >= 0) stopSsbPlayback();
+    if (typeof smCleanupAudio === 'function') smCleanupAudio();
     if (pc) { pc.close(); pc = null; }
     if (localAudioStream) { localAudioStream.getTracks().forEach(t => t.stop()); localAudioStream = null; }
     if (remoteAudio) { remoteAudio.srcObject = null; }
@@ -6705,6 +6711,435 @@
     // Nothing to close — push state back so next press also gets caught
     history.pushState({ echocat: true }, '');
   });
+
+  // ── POTACAT Speakermic ────────────────────────────────────
+  // BLE-connected speaker/microphone for hands-free operation.
+  // https://github.com/Waffleslop/potacat-speakermic
+
+  // ── IMA-ADPCM Codec ──
+  var SM_STEP = [7,8,9,10,11,12,13,14,16,17,19,21,23,25,28,31,34,37,41,45,50,55,60,66,73,80,88,97,107,118,130,143,157,173,190,209,230,253,279,307,337,371,408,449,494,544,598,658,724,796,876,963,1060,1166,1282,1411,1552,1707,1878,2066,2272,2499,2749,3024,3327,3660,4026,4428,4871,5358,5894,6484,7132,7845,8630,9493,10442,11487,12635,13899,15289,16818,18500,20350,22385,24623,27086,29794,32767];
+  var SM_IDX = [-1,-1,-1,-1,2,4,6,8,-1,-1,-1,-1,2,4,6,8];
+
+  function smAdpcmDecode(input, state) {
+    if (input.length < 4) return new Float32Array(0);
+    state.p = (input[0] | (input[1] << 8)) << 16 >> 16;
+    state.i = Math.min(88, Math.max(0, input[2]));
+    var dl = input.length - 4, pcm = new Float32Array(dl * 2), sc = 0;
+    for (var b = 0; b < dl; b++) {
+      for (var ni = 0; ni < 2; ni++) {
+        var nib = ni === 0 ? (input[4 + b] & 0x0F) : ((input[4 + b] >> 4) & 0x0F);
+        var step = SM_STEP[state.i], delta = (step >> 3);
+        if (nib & 4) delta += step;
+        if (nib & 2) delta += (step >> 1);
+        if (nib & 1) delta += (step >> 2);
+        if (nib & 8) delta = -delta;
+        state.p = Math.max(-32768, Math.min(32767, state.p + delta));
+        state.i = Math.min(88, Math.max(0, state.i + SM_IDX[nib]));
+        pcm[sc++] = state.p / 32768.0;
+      }
+    }
+    return pcm.subarray(0, sc);
+  }
+
+  function smAdpcmEncode(pcmInt16, state) {
+    var n = pcmInt16.length, out = new Uint8Array(4 + Math.ceil(n / 2));
+    out[0] = state.p & 0xFF; out[1] = (state.p >> 8) & 0xFF;
+    out[2] = state.i; out[3] = 0;
+    var bi = 0, hi = false;
+    for (var i = 0; i < n; i++) {
+      var step = SM_STEP[state.i], diff = pcmInt16[i] - state.p, nib = 0;
+      if (diff < 0) { nib = 8; diff = -diff; }
+      if (diff >= step) { nib |= 4; diff -= step; }
+      if (diff >= (step >> 1)) { nib |= 2; diff -= (step >> 1); }
+      if (diff >= (step >> 2)) { nib |= 1; }
+      var d2 = (SM_STEP[state.i] >> 3);
+      if (nib & 4) d2 += SM_STEP[state.i];
+      if (nib & 2) d2 += (SM_STEP[state.i] >> 1);
+      if (nib & 1) d2 += (SM_STEP[state.i] >> 2);
+      if (nib & 8) d2 = -d2;
+      state.p = Math.max(-32768, Math.min(32767, state.p + d2));
+      state.i = Math.min(88, Math.max(0, state.i + SM_IDX[nib]));
+      if (!hi) { out[4 + bi] = nib & 0x0F; hi = true; }
+      else { out[4 + bi] |= (nib << 4); bi++; hi = false; }
+    }
+    return out;
+  }
+
+  // ── BLE UUIDs ──
+  var SM_SVC  = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+  var SM_TX   = 'f47ac10b-58cc-4372-a567-0e02b2c30001';
+  var SM_RX   = 'f47ac10b-58cc-4372-a567-0e02b2c30002';
+  var SM_CTL  = 'f47ac10b-58cc-4372-a567-0e02b2c30003';
+  var SM_DEV  = 'f47ac10b-58cc-4372-a567-0e02b2c30004';
+
+  // ── State ──
+  var smDevice = null, smServer = null;
+  var smTxChar = null, smRxChar = null, smCtlChar = null, smDevChar = null;
+  var smConnected = false;
+  var smEnabled = localStorage.getItem('echocat-speakermic-enabled') === 'true';
+  var smAutoReconnect = localStorage.getItem('echocat-speakermic-auto-reconnect') !== 'false';
+  var smBatteryPct = 0;
+  var smRxDecState = { p: 0, i: 0 };
+  var smTxEncState = { p: 0, i: 0 };
+  var smMicTrack = null;
+  var smOriginalTrack = null;
+  var smCaptureNode = null;
+  var smMicAudioCtx = null;
+  var smMicBufNode = null;
+  var smMicPcmQueue = [];
+
+  // ── DOM Elements ──
+  var speakermicBtn = document.getElementById('speakermic-btn');
+  var smIcon = document.getElementById('speakermic-icon');
+  var smLabel = document.getElementById('speakermic-label');
+  var soSmEnable = document.getElementById('so-speakermic-enable');
+  var soSmSettings = document.getElementById('so-speakermic-settings');
+  var soSmConnect = document.getElementById('so-speakermic-connect');
+  var soSmStatus = document.getElementById('so-speakermic-status');
+  var soSmDetails = document.getElementById('so-speakermic-details');
+  var soSmVolRow = document.getElementById('so-speakermic-vol-row');
+  var soSmBattFill = document.getElementById('so-speakermic-batt-fill');
+  var soSmBattPct = document.getElementById('so-speakermic-batt-pct');
+  var soSmVol = document.getElementById('so-speakermic-vol');
+  var soSmVolLabel = document.getElementById('so-speakermic-vol-label');
+  var soSmReconnect = document.getElementById('so-speakermic-reconnect');
+
+  // ── Feature Detection ──
+  var smHasBluetooth = !!(navigator.bluetooth);
+
+  // ── Enable Toggle ──
+  function smSetEnabled(on) {
+    smEnabled = on;
+    localStorage.setItem('echocat-speakermic-enabled', on);
+    if (soSmEnable) {
+      soSmEnable.classList.toggle('active', on);
+      soSmEnable.textContent = on ? 'On' : 'Off';
+    }
+    if (soSmSettings) soSmSettings.style.display = on ? '' : 'none';
+    if (on && audioEnabled) {
+      speakermicBtn.classList.remove('hidden');
+    } else {
+      speakermicBtn.classList.add('hidden');
+      if (smConnected) smDisconnect();
+    }
+  }
+
+  // Restore saved state
+  if (soSmEnable) {
+    if (!smHasBluetooth) {
+      soSmEnable.textContent = 'N/A';
+      soSmEnable.disabled = true;
+      soSmEnable.style.opacity = '0.4';
+      soSmEnable.parentElement.querySelector('span').textContent = 'Web Bluetooth not supported';
+    } else {
+      smSetEnabled(smEnabled);
+      soSmEnable.addEventListener('click', function () { smSetEnabled(!smEnabled); });
+    }
+  }
+
+  // Restore volume
+  var smSavedVol = localStorage.getItem('echocat-speakermic-vol');
+  if (smSavedVol && soSmVol) { soSmVol.value = smSavedVol; soSmVolLabel.textContent = smSavedVol + '%'; }
+
+  // Restore auto-reconnect
+  if (soSmReconnect) {
+    soSmReconnect.classList.toggle('active', smAutoReconnect);
+    soSmReconnect.textContent = smAutoReconnect ? 'On' : 'Off';
+    soSmReconnect.addEventListener('click', function () {
+      smAutoReconnect = !smAutoReconnect;
+      soSmReconnect.classList.toggle('active', smAutoReconnect);
+      soSmReconnect.textContent = smAutoReconnect ? 'On' : 'Off';
+      localStorage.setItem('echocat-speakermic-auto-reconnect', smAutoReconnect);
+    });
+  }
+
+  // Volume slider
+  if (soSmVol) {
+    soSmVol.addEventListener('input', function () {
+      var v = parseInt(soSmVol.value);
+      soSmVolLabel.textContent = v + '%';
+      smSendControl(0x04, v);
+      localStorage.setItem('echocat-speakermic-vol', v);
+    });
+  }
+
+  // ── Connect / Disconnect ──
+  async function smConnect() {
+    if (!smHasBluetooth) return;
+    if (smConnected) return;
+    smUpdateBtn('connecting');
+    try {
+      smDevice = await navigator.bluetooth.requestDevice({
+        filters: [{ services: [SM_SVC] }]
+      });
+      smDevice.addEventListener('gattserverdisconnected', smOnDisconnect);
+      smServer = await smDevice.gatt.connect();
+      var svc = await smServer.getPrimaryService(SM_SVC);
+
+      smTxChar = await svc.getCharacteristic(SM_TX);
+      smRxChar = await svc.getCharacteristic(SM_RX);
+      smCtlChar = await svc.getCharacteristic(SM_CTL);
+      smDevChar = await svc.getCharacteristic(SM_DEV);
+
+      await smTxChar.startNotifications();
+      smTxChar.addEventListener('characteristicvaluechanged', smOnTxAudio);
+
+      await smCtlChar.startNotifications();
+      smCtlChar.addEventListener('characteristicvaluechanged', smOnControl);
+
+      // Read initial device info
+      try {
+        var dv = await smDevChar.readValue();
+        smBatteryPct = dv.getUint8(0);
+      } catch (e) {}
+
+      // Tell ESP32 to start audio
+      smSendControl(0x05, 1);
+
+      // Set saved volume
+      var v = parseInt(localStorage.getItem('echocat-speakermic-vol') || '70');
+      smSendControl(0x04, v);
+
+      smRxDecState = { p: 0, i: 0 };
+      smTxEncState = { p: 0, i: 0 };
+      smConnected = true;
+
+      // Set up audio bridges if WebRTC is already connected
+      if (pc && audioEnabled) {
+        smSetupTxBridge();
+        if (remoteAudio && remoteAudio.srcObject) {
+          smSetupRxBridge(remoteAudio.srcObject);
+        }
+      }
+
+      smUpdateBtn('connected');
+      smUpdateSettings();
+      console.log('[Speakermic] Connected to ' + (smDevice.name || 'device'));
+    } catch (err) {
+      console.error('[Speakermic] Connect failed:', err);
+      smUpdateBtn('error');
+      setTimeout(function () { if (!smConnected) smUpdateBtn('idle'); }, 3000);
+    }
+  }
+
+  function smDisconnect() {
+    if (smDevice && smDevice.gatt.connected) {
+      try { smSendControl(0x05, 0); } catch (e) {}
+      smDevice.gatt.disconnect();
+    }
+    smCleanupAll();
+  }
+
+  function smOnDisconnect() {
+    console.log('[Speakermic] Disconnected');
+    smCleanupAll();
+    if (smAutoReconnect && smEnabled) {
+      smUpdateBtn('idle');
+      if (soSmStatus) soSmStatus.textContent = 'Disconnected \u2014 tap Mic to reconnect';
+    }
+  }
+
+  function smCleanupAll() {
+    smCleanupAudio();
+    smConnected = false;
+    smTxChar = null; smRxChar = null; smCtlChar = null; smDevChar = null;
+    smServer = null;
+    smUpdateBtn('idle');
+    smUpdateSettings();
+  }
+
+  function smCleanupAudio() {
+    if (smOriginalTrack && pc) {
+      try {
+        var senders = pc.getSenders();
+        var audioSender = senders.find(function (s) { return s.track && s.track.kind === 'audio'; });
+        if (audioSender) audioSender.replaceTrack(smOriginalTrack).catch(function () {});
+      } catch (e) {}
+    }
+    smOriginalTrack = null;
+    smMicTrack = null;
+    smMicPcmQueue = [];
+    if (smMicBufNode) { try { smMicBufNode.disconnect(); } catch (e) {} smMicBufNode = null; }
+    if (smMicAudioCtx) { try { smMicAudioCtx.close(); } catch (e) {} smMicAudioCtx = null; }
+    if (smCaptureNode) { try { smCaptureNode.disconnect(); } catch (e) {} smCaptureNode = null; }
+  }
+
+  // ── TX Audio Bridge: ESP32 Mic -> WebRTC ──
+  function smSetupTxBridge() {
+    if (!pc) return;
+    var senders = pc.getSenders();
+    var audioSender = senders.find(function (s) { return s.track && s.track.kind === 'audio'; });
+    if (!audioSender) { console.warn('[Speakermic] No audio sender on pc'); return; }
+
+    smOriginalTrack = audioSender.track;
+    smMicAudioCtx = new (window.AudioContext || window.webkitAudioContext)({ sampleRate: 8000 });
+    smMicPcmQueue = [];
+
+    smMicBufNode = smMicAudioCtx.createScriptProcessor(160, 0, 1);
+    smMicBufNode.onaudioprocess = function (e) {
+      var out = e.outputBuffer.getChannelData(0);
+      if (smMicPcmQueue.length > 0) {
+        var frame = smMicPcmQueue.shift();
+        for (var i = 0; i < out.length && i < frame.length; i++) out[i] = frame[i];
+        for (var j = frame.length; j < out.length; j++) out[j] = 0;
+      } else {
+        for (var k = 0; k < out.length; k++) out[k] = 0;
+      }
+    };
+
+    var dest = smMicAudioCtx.createMediaStreamDestination();
+    smMicBufNode.connect(dest);
+    smMicTrack = dest.stream.getAudioTracks()[0];
+    smMicTrack.enabled = false;
+
+    audioSender.replaceTrack(smMicTrack).then(function () {
+      console.log('[Speakermic] TX bridge active');
+    }).catch(function (err) {
+      console.error('[Speakermic] replaceTrack failed:', err);
+    });
+  }
+
+  // ── RX Audio Bridge: WebRTC -> ESP32 Speaker ──
+  function smSetupRxBridge(remoteStream) {
+    if (!audioCtx || !gainNode || !smRxChar) return;
+    if (smCaptureNode) { try { smCaptureNode.disconnect(); } catch (e) {} }
+
+    var ratio = audioCtx.sampleRate / 8000;
+    var buffer = [];
+    smTxEncState = { p: 0, i: 0 };
+
+    smCaptureNode = audioCtx.createScriptProcessor(4096, 1, 1);
+    smCaptureNode.onaudioprocess = function (e) {
+      if (!smConnected || !smRxChar) return;
+      var input = e.inputBuffer.getChannelData(0);
+      for (var i = 0; i < input.length; i += ratio) {
+        var idx = Math.floor(i);
+        if (idx < input.length) {
+          buffer.push(Math.round(Math.max(-1, Math.min(1, input[idx])) * 32767));
+        }
+      }
+      while (buffer.length >= 160) {
+        var frame = new Int16Array(buffer.splice(0, 160));
+        var adpcm = smAdpcmEncode(frame, smTxEncState);
+        smRxChar.writeValueWithoutResponse(adpcm).catch(function () {});
+      }
+    };
+
+    gainNode.connect(smCaptureNode);
+    smCaptureNode.connect(audioCtx.destination);
+    console.log('[Speakermic] RX bridge active');
+  }
+
+  // ── BLE Notification Handlers ──
+  function smOnTxAudio(event) {
+    if (!smConnected) return;
+    var data = new Uint8Array(event.target.value.buffer);
+    if (data.length < 5) return;
+    var pcm = smAdpcmDecode(data, smRxDecState);
+    if (pcm.length === 0) return;
+    if (smMicTrack && smMicPcmQueue) {
+      smMicPcmQueue.push(pcm);
+      while (smMicPcmQueue.length > 10) smMicPcmQueue.shift();
+    }
+  }
+
+  function smOnControl(event) {
+    var d = new Uint8Array(event.target.value.buffer);
+    if (d.length < 2) return;
+    switch (d[0]) {
+      case 0x01: // PTT from ESP32 button
+        if (d[1] === 1) {
+          if (smMicTrack) smMicTrack.enabled = true;
+          pttStart();
+        } else {
+          pttStop();
+          if (smMicTrack) smMicTrack.enabled = false;
+        }
+        break;
+      case 0x02: // Battery
+        smBatteryPct = d[1];
+        smUpdateBtn(smConnected ? 'connected' : 'idle');
+        smUpdateBattery(d[1]);
+        break;
+    }
+  }
+
+  function smSendControl(cmd, val) {
+    if (!smCtlChar || !smConnected) return;
+    var data = new Uint8Array([cmd, val]);
+    smCtlChar.writeValueWithResponse(data).catch(function () {});
+  }
+
+  // ── UI Updates ──
+  function smUpdateBtn(state) {
+    if (!speakermicBtn) return;
+    speakermicBtn.classList.remove('mic-connected', 'mic-connecting', 'mic-error');
+    switch (state) {
+      case 'connecting':
+        speakermicBtn.classList.add('mic-connecting');
+        smLabel.textContent = '...';
+        break;
+      case 'connected':
+        speakermicBtn.classList.add('mic-connected');
+        smLabel.textContent = smBatteryPct > 0 ? smBatteryPct + '%' : 'On';
+        break;
+      case 'error':
+        speakermicBtn.classList.add('mic-error');
+        smLabel.textContent = 'Err';
+        break;
+      default:
+        smLabel.textContent = 'Mic';
+        break;
+    }
+  }
+
+  function smUpdateSettings() {
+    if (!soSmConnect) return;
+    if (smConnected) {
+      soSmConnect.textContent = 'Disconnect';
+      soSmConnect.style.borderColor = 'var(--accent)';
+      soSmConnect.style.color = 'var(--accent)';
+      soSmStatus.textContent = smDevice ? (smDevice.name || 'Connected') : 'Connected';
+      soSmStatus.style.color = 'var(--pota)';
+      if (soSmDetails) soSmDetails.style.display = '';
+      if (soSmVolRow) soSmVolRow.style.display = '';
+      smUpdateBattery(smBatteryPct);
+    } else {
+      soSmConnect.textContent = 'Connect';
+      soSmConnect.style.borderColor = '';
+      soSmConnect.style.color = '';
+      soSmStatus.textContent = 'Not connected';
+      soSmStatus.style.color = 'var(--text-dim)';
+      if (soSmDetails) soSmDetails.style.display = 'none';
+      if (soSmVolRow) soSmVolRow.style.display = 'none';
+    }
+  }
+
+  function smUpdateBattery(pct) {
+    if (soSmBattFill) soSmBattFill.style.width = pct + '%';
+    if (soSmBattPct) soSmBattPct.textContent = pct + '%';
+    if (soSmBattFill) {
+      if (pct > 25) soSmBattFill.style.background = 'var(--pota)';
+      else if (pct > 10) soSmBattFill.style.background = '#facc15';
+      else soSmBattFill.style.background = 'var(--accent)';
+    }
+  }
+
+  // ── Button Handlers ──
+  if (speakermicBtn) {
+    speakermicBtn.addEventListener('click', function () {
+      if (smConnected) smDisconnect();
+      else smConnect();
+    });
+  }
+  if (soSmConnect) {
+    soSmConnect.addEventListener('click', function () {
+      if (smConnected) smDisconnect();
+      else smConnect();
+    });
+  }
+
+  // ── End Speakermic ───────────────────────────────────────
 
   // Auto-connect on page load
   connect('');


### PR DESCRIPTION
## Summary

- Adds BLE-connected speaker/microphone support to ECHOCAT's remote page
- Opt-in feature: **Settings -> Speakermic -> Enable** (off by default, zero UI impact)
- When enabled, "Mic" button appears in the bottom bar for connecting to a POTACAT-MIC device
- Audio bridges into existing WebRTC connection — zero server-side changes

## Changes

| File | Lines | What |
|------|-------|------|
| `renderer/remote.css` | +34 | Mic button styles (idle/connected/connecting/error states) |
| `renderer/remote.html` | +48 | Mic button in bottom bar + Speakermic settings section |
| `renderer/remote.js` | +435 | ADPCM codec, Web Bluetooth bridge, audio routing, settings |

**6 one-line hooks** into existing functions (`showAudioControls`, `showConnectPrompt`, `pc.ontrack`, `stopAudio`, `pttStart`, `pttStop`). The rest is a self-contained block appended before the IIFE close.

## How It Works

- **TX**: ESP32 mic -> IMA-ADPCM -> BLE -> phone decodes -> replaces WebRTC sender track -> radio
- **RX**: Radio -> WebRTC -> phone captures -> ADPCM encode -> BLE write -> ESP32 speaker
- **PTT**: ESP32 hardware button -> BLE control notify -> existing `pttStart()`/`pttStop()`

## Hardware

See [potacat-speakermic](https://github.com/Waffleslop/potacat-speakermic) for firmware, BOM (~$28), wiring guide, and 3D case.

## Test plan

- [ ] Verify ECHOCAT works normally with Speakermic disabled (default)
- [ ] Toggle Enable On in settings, verify Mic button appears in bottom bar
- [ ] Connect to POTACAT-MIC device via BLE
- [ ] Test TX: PTT from ESP32 button, verify mic audio reaches radio
- [ ] Test RX: Verify radio audio plays through ESP32 speaker
- [ ] Disconnect speakermic, verify phone mic track restores
- [ ] Toggle Enable Off, verify Mic button disappears
- [ ] Verify "N/A" shown on browsers without Web Bluetooth (Safari)

🤖 Generated with [Claude Code](https://claude.com/claude-code)