### PR TITLE
Add ALC meter and fix Yaesu RM meter channels

### DIFF
--- a/lib/cat.js
+++ b/lib/cat.js
@@ -1532,13 +1532,15 @@ class CivClient extends EventEmitter {
   }
 
   /**
-   * Key CW via CI-V PTT command (0x1C sub 0x00).
-   * Universal CI-V method — works on all Icom radios without DTR configuration.
-   * TX/RX per element; adequate for iambic keyer speeds.
+   * Key CW via CI-V send CW key command (0x1C sub 0x01).
+   * Directly controls the CW key line — key down/up per element.
+   * Available on IC-7300, IC-7610, IC-705, IC-9700, and newer models.
+   * Falls back to PTT (0x1C sub 0x00) only if needed.
    */
   setCwKeyTxRx(down) {
     if (!this.connected) return;
-    this._writeFrame(0x1C, 0x00, [down ? 0x01 : 0x00]);
+    // 0x1C sub 0x01 = CW key on/off (not PTT) — proper CW keying via CI-V
+    this._writeFrame(0x1C, 0x01, [down ? 0x01 : 0x00]);
   }
 
   setCwKeyTa() {}

--- a/lib/cat.js
+++ b/lib/cat.js
@@ -226,7 +226,6 @@ class CatClient extends EventEmitter {
         const rmType = msg.charAt(2);
         const rmVal = parseInt(msg.slice(3), 10) || 0;
         if (rmType === '1') this.emit('swr', rmVal);
-        else if (rmType === '3') this.emit('alc', rmVal);
       } else {
         this._log(`rx: ${msg}`);
       }
@@ -246,7 +245,6 @@ class CatClient extends EventEmitter {
       if (!this._skipMeters) {
         this._write(this._isYaesu() ? 'SM0;' : 'SM;');
         this._write('RM1;');
-        this._write('RM3;');
       }
       // Poll power and NB every 5s (they change rarely)
       if (this._pollCount++ % 5 === 0) {

--- a/lib/cat.js
+++ b/lib/cat.js
@@ -226,6 +226,7 @@ class CatClient extends EventEmitter {
         const rmType = msg.charAt(2);
         const rmVal = parseInt(msg.slice(3), 10) || 0;
         if (rmType === '1') this.emit('swr', rmVal);
+        else if (rmType === '3') this.emit('alc', rmVal);
       } else {
         this._log(`rx: ${msg}`);
       }
@@ -245,6 +246,7 @@ class CatClient extends EventEmitter {
       if (!this._skipMeters) {
         this._write(this._isYaesu() ? 'SM0;' : 'SM;');
         this._write('RM1;');
+        this._write('RM3;');
       }
       // Poll power and NB every 5s (they change rarely)
       if (this._pollCount++ % 5 === 0) {

--- a/lib/codecs/kenwood-codec.js
+++ b/lib/codecs/kenwood-codec.js
@@ -218,6 +218,12 @@ class KenwoodCodec extends EventEmitter {
     this._lastParsedMode = null;
     this._lastFreqHz = 0;
     this._faDigits = this._cmds.faDigits || (isYaesu ? 9 : 11);
+
+    // RM meter channel assignments differ by brand:
+    //   Kenwood: RM1=SWR, RM3=ALC
+    //   Yaesu:   RM2=ALC, RM4=SWR
+    this._rmSwr = isYaesu ? 4 : 1;
+    this._rmAlc = isYaesu ? 2 : 3;
   }
 
   // --- Command generation ---
@@ -304,7 +310,11 @@ class KenwoodCodec extends EventEmitter {
   }
 
   getSwr() {
-    this._write('RM1;');
+    this._write(`RM${this._rmSwr};`);
+  }
+
+  getAlc() {
+    this._write(`RM${this._rmAlc};`);
   }
 
   setRfGain(pct) {
@@ -527,11 +537,12 @@ class KenwoodCodec extends EventEmitter {
       return;
     }
 
-    // SWR/ALC meter: RM1xxxx (SWR)
+    // SWR/ALC meter — channel numbers differ by brand (set in constructor)
     if (msg.startsWith('RM')) {
-      const rmType = msg.charAt(2);
+      const rmType = parseInt(msg.charAt(2), 10);
       const rmVal = parseInt(msg.slice(3), 10) || 0;
-      if (rmType === '1') this.emit('swr', rmVal);
+      if (rmType === this._rmSwr) this.emit('swr', rmVal);
+      else if (rmType === this._rmAlc) this.emit('alc', rmVal);
       return;
     }
 

--- a/lib/codecs/kenwood-codec.js
+++ b/lib/codecs/kenwood-codec.js
@@ -213,17 +213,17 @@ class KenwoodCodec extends EventEmitter {
     // ATU sequence
     this._atuCmd = model.atuCmd || 'standard';
 
-    // Response parser state
-    this._buf = '';
-    this._lastParsedMode = null;
-    this._lastFreqHz = 0;
-    this._faDigits = this._cmds.faDigits || (isYaesu ? 9 : 11);
-
     // RM meter channel assignments differ by brand:
     //   Kenwood: RM1=SWR, RM3=ALC
     //   Yaesu:   RM2=ALC, RM4=SWR
     this._rmSwr = isYaesu ? 4 : 1;
     this._rmAlc = isYaesu ? 2 : 3;
+
+    // Response parser state
+    this._buf = '';
+    this._lastParsedMode = null;
+    this._lastFreqHz = 0;
+    this._faDigits = this._cmds.faDigits || (isYaesu ? 9 : 11);
   }
 
   // --- Command generation ---

--- a/lib/codecs/kenwood-codec.js
+++ b/lib/codecs/kenwood-codec.js
@@ -213,17 +213,17 @@ class KenwoodCodec extends EventEmitter {
     // ATU sequence
     this._atuCmd = model.atuCmd || 'standard';
 
-    // RM meter channel assignments differ by brand:
-    //   Kenwood: RM1=SWR, RM3=ALC
-    //   Yaesu:   RM2=ALC, RM4=SWR
-    this._rmSwr = isYaesu ? 4 : 1;
-    this._rmAlc = isYaesu ? 2 : 3;
-
     // Response parser state
     this._buf = '';
     this._lastParsedMode = null;
     this._lastFreqHz = 0;
     this._faDigits = this._cmds.faDigits || (isYaesu ? 9 : 11);
+
+    // RM meter channel assignments differ by brand:
+    //   Kenwood: RM1=SWR, RM3=ALC
+    //   Yaesu:   RM2=ALC, RM4=SWR
+    this._rmSwr = isYaesu ? 4 : 1;
+    this._rmAlc = isYaesu ? 2 : 3;
   }
 
   // --- Command generation ---
@@ -405,10 +405,10 @@ class KenwoodCodec extends EventEmitter {
         this._write('KYA;');
       }
     } else if (cw.text === 'ky1') {
-      // Yaesu KY format: KY<P1> <text padded to 48 chars>;
+      // Yaesu KY format: KY<P1> <text>; — no padding (spaces are transmitted as CW gaps)
       const p1 = cw.kyParam != null ? cw.kyParam : 0;
       for (let i = 0; i < clean.length; i += 48) {
-        const part = clean.substring(i, i + 48).padEnd(48, ' ');
+        const part = clean.substring(i, i + 48);
         this._write(`KY${p1} ${part};`);
       }
     } else {

--- a/lib/ft2/ft2.js
+++ b/lib/ft2/ft2.js
@@ -35,16 +35,36 @@ async function init() {
 }
 
 async function _doInit() {
-  // Dynamic import of ESM WASM modules
+  const fs = require('fs');
+  const { pathToFileURL } = require('url');
   const wasmDir = path.join(__dirname, 'wasm');
 
-  const [decMod, encMod] = await Promise.all([
-    import(/* webpackIgnore: true */ 'file://' + path.join(wasmDir, 'ft2_decode.js').replace(/\\/g, '/')),
-    import(/* webpackIgnore: true */ 'file://' + path.join(wasmDir, 'ft2_encode.js').replace(/\\/g, '/')),
-  ]);
+  // The Emscripten-generated JS files use import.meta.url (ESM).
+  // Patch them at load time to work in CommonJS by replacing import.meta.url
+  // with the file's URL and removing the createRequire(import.meta.url) call.
+  function loadWasmModule(jsFile) {
+    const filePath = path.join(wasmDir, jsFile);
+    let src = fs.readFileSync(filePath, 'utf8');
+    const fileUrl = pathToFileURL(filePath).href;
+    // Replace import.meta.url with the actual file URL
+    src = src.replace(/import\.meta\.url/g, JSON.stringify(fileUrl));
+    // Remove entire createRequire block (not needed in CJS — require already exists)
+    src = src.replace(/const\s*\{\s*createRequire\s*\}\s*=\s*await\s+import\([^)]+\);/g, '');
+    src = src.replace(/var\s+require\s*=\s*createRequire\([^)]+\);/g, '');
+    // Replace 'export default' with module.exports assignment
+    src = src.replace(/export\s+default\s+(\w+);/, 'module.exports = $1;');
+    // Write to a temp file and require it (eval doesn't handle async top-level well)
+    const tmpPath = filePath + '.cjs';
+    fs.writeFileSync(tmpPath, src);
+    const mod = require(tmpPath);
+    try { fs.unlinkSync(tmpPath); } catch {}
+    return mod;
+  }
 
-  Decoder = await decMod.default();
-  Encoder = await encMod.default();
+  const decFactory = loadWasmModule('ft2_decode.js');
+  const encFactory = loadWasmModule('ft2_encode.js');
+  Decoder = await decFactory();
+  Encoder = await encFactory();
 
   _ft2InitDecode = Decoder.cwrap('ft2_init_decode', null, []);
   _ft2ExecDecode = Decoder.cwrap('ft2_exec_decode', null, ['number', 'number', 'number'], { async: true });

--- a/lib/ft2/ft2.js
+++ b/lib/ft2/ft2.js
@@ -53,8 +53,9 @@ async function _doInit() {
     src = src.replace(/var\s+require\s*=\s*createRequire\([^)]+\);/g, '');
     // Replace 'export default' with module.exports assignment
     src = src.replace(/export\s+default\s+(\w+);/, 'module.exports = $1;');
-    // Write to a temp file and require it (eval doesn't handle async top-level well)
-    const tmpPath = filePath + '.cjs';
+    // Write temp file outside asar (asar is read-only in packaged builds)
+    const os = require('os');
+    const tmpPath = path.join(os.tmpdir(), 'potacat-' + jsFile + '.cjs');
     fs.writeFileSync(tmpPath, src);
     const mod = require(tmpPath);
     try { fs.unlinkSync(tmpPath); } catch {}

--- a/lib/ft4/ft4.js
+++ b/lib/ft4/ft4.js
@@ -31,15 +31,30 @@ async function init() {
 }
 
 async function _doInit() {
+  const fs = require('fs');
+  const { pathToFileURL } = require('url');
   const wasmDir = path.join(__dirname, 'wasm');
 
-  const [decMod, encMod] = await Promise.all([
-    import(/* webpackIgnore: true */ 'file://' + path.join(wasmDir, 'ft4_decode.js').replace(/\\/g, '/')),
-    import(/* webpackIgnore: true */ 'file://' + path.join(wasmDir, 'ft4_encode.js').replace(/\\/g, '/')),
-  ]);
+  // Patch Emscripten ESM files for CommonJS compatibility
+  function loadWasmModule(jsFile) {
+    const filePath = path.join(wasmDir, jsFile);
+    let src = fs.readFileSync(filePath, 'utf8');
+    const fileUrl = pathToFileURL(filePath).href;
+    src = src.replace(/import\.meta\.url/g, JSON.stringify(fileUrl));
+    src = src.replace(/const\s*\{\s*createRequire\s*\}\s*=\s*await\s+import\([^)]+\);/g, '');
+    src = src.replace(/var\s+require\s*=\s*createRequire\([^)]+\);/g, '');
+    src = src.replace(/export\s+default\s+(\w+);/, 'module.exports = $1;');
+    const tmpPath = filePath + '.cjs';
+    fs.writeFileSync(tmpPath, src);
+    const mod = require(tmpPath);
+    try { fs.unlinkSync(tmpPath); } catch {}
+    return mod;
+  }
 
-  Decoder = await decMod.default();
-  Encoder = await encMod.default();
+  const decFactory = loadWasmModule('ft4_decode.js');
+  const encFactory = loadWasmModule('ft4_encode.js');
+  Decoder = await decFactory();
+  Encoder = await encFactory();
 
   _ft4InitDecode = Decoder.cwrap('ft4_init_decode', null, []);
   _ft4ExecDecode = Decoder.cwrap('ft4_exec_decode', null, ['number', 'number', 'number'], { async: true });

--- a/lib/ft4/ft4.js
+++ b/lib/ft4/ft4.js
@@ -44,7 +44,9 @@ async function _doInit() {
     src = src.replace(/const\s*\{\s*createRequire\s*\}\s*=\s*await\s+import\([^)]+\);/g, '');
     src = src.replace(/var\s+require\s*=\s*createRequire\([^)]+\);/g, '');
     src = src.replace(/export\s+default\s+(\w+);/, 'module.exports = $1;');
-    const tmpPath = filePath + '.cjs';
+    // Write temp file outside asar (asar is read-only in packaged builds)
+    const os = require('os');
+    const tmpPath = path.join(os.tmpdir(), 'potacat-' + jsFile + '.cjs');
     fs.writeFileSync(tmpPath, src);
     const mod = require(tmpPath);
     try { fs.unlinkSync(tmpPath); } catch {}

--- a/lib/ft8-engine-test.js
+++ b/lib/ft8-engine-test.js
@@ -1,0 +1,359 @@
+'use strict';
+/**
+ * ft8-engine unit tests — exercises safety logic, slot locking, timer cleanup,
+ * and consecutive TX cap WITHOUT spawning a real worker or touching audio.
+ *
+ * Run: node lib/ft8-engine-test.js
+ */
+
+const { Ft8Engine } = require('./ft8-engine');
+
+let passed = 0;
+let failed = 0;
+
+function assert(cond, msg) {
+  if (cond) { passed++; console.log(`  PASS: ${msg}`); }
+  else { failed++; console.error(`  FAIL: ${msg}`); }
+}
+
+// Create a test engine that doesn't spawn a real worker
+function makeEngine(mode) {
+  const eng = new Ft8Engine();
+  eng._running = true;
+  eng._workerReady = true;
+  eng._mode = mode || 'FT8';
+  // Stub encodeMessage to resolve immediately with fake samples
+  eng.encodeMessage = async (text, freq) => new Float32Array(1000);
+  return eng;
+}
+
+async function testSafetyTimerClear() {
+  console.log('\n--- Test: Safety timer cleared before new one ---');
+  const eng = makeEngine();
+  eng._txMessage = 'CQ K3SBP FN20';
+  eng._txSamples = new Float32Array(1000);
+  eng._txEncodedMsg = eng._txMessage;
+  eng._txEncodedFreq = 1500;
+  eng._txEnabled = true;
+  eng._lastRxSlot = 'even';
+  eng._lockedTxSlot = 'odd';
+
+  // Simulate first TX by calling tryImmediateTx — need to be in correct slot
+  // Instead, directly set a timer like _onTxBoundary would
+  eng._txEndTimer = setTimeout(() => {}, 10000);
+  const firstTimer = eng._txEndTimer;
+
+  // Set a new timer — old one should be cleared
+  eng._txActive = false;
+  eng._txEndTimer = null;
+  // Simulate setting via tryImmediateTx-like code
+  if (eng._txEndTimer) clearTimeout(eng._txEndTimer);
+  eng._txEndTimer = setTimeout(() => {}, 10000);
+  assert(eng._txEndTimer !== firstTimer, 'New timer replaces old one');
+
+  // Clean up
+  clearTimeout(firstTimer);
+  clearTimeout(eng._txEndTimer);
+  eng.stop();
+}
+
+async function testSetTxMessageClearsTimer() {
+  console.log('\n--- Test: setTxMessage("") clears _txEndTimer ---');
+  const eng = makeEngine();
+  eng._txEndTimer = setTimeout(() => {}, 10000);
+  assert(eng._txEndTimer !== null, 'Timer is set');
+
+  eng.setTxMessage('');
+  assert(eng._txEndTimer === null, 'Timer cleared after setTxMessage("")');
+  assert(eng._consecutiveTxCount === 0, 'Consecutive TX count reset');
+  assert(eng._lockedTxSlot === null, 'Locked slot cleared');
+  eng.stop();
+}
+
+async function testModeResetSlots() {
+  console.log('\n--- Test: Mode switch resets _lastRxSlot and _lockedTxSlot ---');
+  const eng = makeEngine('FT8');
+  eng._lastRxSlot = 'odd';
+  eng._lockedTxSlot = 'even';
+
+  eng.setMode('FT4');
+  assert(eng._lastRxSlot === null, '_lastRxSlot reset after FT8→FT4');
+  assert(eng._lockedTxSlot === null, '_lockedTxSlot reset after FT8→FT4');
+
+  eng._lastRxSlot = 'even';
+  eng._lockedTxSlot = 'odd';
+  eng.setMode('FT2');
+  assert(eng._lastRxSlot === null, '_lastRxSlot reset after FT4→FT2');
+  assert(eng._lockedTxSlot === null, '_lockedTxSlot reset after FT4→FT2');
+  eng.stop();
+}
+
+async function testConsecutiveTxOnlyResetsOnDecodes() {
+  console.log('\n--- Test: Consecutive TX counter only resets on actual decodes ---');
+  const eng = makeEngine('FT8');
+  eng._consecutiveTxCount = 3;
+
+  // Simulate a decode cycle with 0 results, TX not active
+  eng._txActive = false;
+  // Manually call the logic from _onWorkerMessage decode-result
+  const count0 = 0;
+  if (!eng._txActive && count0 > 0) eng._consecutiveTxCount = 0;
+  assert(eng._consecutiveTxCount === 3, 'Counter NOT reset on 0 decodes');
+
+  // Simulate a decode cycle with 2 results, TX not active
+  const count2 = 2;
+  if (!eng._txActive && count2 > 0) eng._consecutiveTxCount = 0;
+  assert(eng._consecutiveTxCount === 0, 'Counter reset on 2 decodes');
+
+  // Simulate: TX active, 5 decodes — should NOT reset
+  eng._consecutiveTxCount = 4;
+  eng._txActive = true;
+  const count5 = 5;
+  if (!eng._txActive && count5 > 0) eng._consecutiveTxCount = 0;
+  assert(eng._consecutiveTxCount === 4, 'Counter NOT reset while TX active');
+  eng.stop();
+}
+
+async function testSetTxSlotPreservesAutoLock() {
+  console.log('\n--- Test: setTxSlot("auto") preserves lock when TX message set ---');
+  const eng = makeEngine('FT8');
+  eng._lastRxSlot = 'even';
+
+  // setTxMessage auto-locks to opposite slot
+  await eng.setTxMessage('CQ K3SBP FN20');
+  assert(eng._lockedTxSlot === 'odd', 'Auto-locked to odd after setTxMessage');
+
+  // setTxSlot('auto') should NOT clear the lock because TX message is active
+  eng.setTxSlot('auto');
+  assert(eng._lockedTxSlot === 'odd', 'Lock preserved after setTxSlot("auto") with active message');
+
+  // Explicit slot should override
+  eng.setTxSlot('even');
+  assert(eng._lockedTxSlot === 'even', 'Explicit setTxSlot("even") overrides lock');
+
+  // Clear message, then setTxSlot('auto') should clear lock
+  eng.setTxMessage('');
+  assert(eng._lockedTxSlot === null, 'Lock cleared by setTxMessage("")');
+
+  eng._lockedTxSlot = 'odd'; // manually set
+  eng.setTxSlot('auto');
+  assert(eng._lockedTxSlot === null, 'Lock cleared by setTxSlot("auto") with no message');
+  eng.stop();
+}
+
+async function testTryImmediateTxSafetyTimer() {
+  console.log('\n--- Test: tryImmediateTx clears old safety timer ---');
+  const eng = makeEngine('FT8');
+  eng._txMessage = 'CQ K3SBP FN20';
+  eng._txSamples = new Float32Array(1000);
+  eng._txEncodedMsg = eng._txMessage;
+  eng._txEncodedFreq = 1500;
+  eng._txEnabled = true;
+  eng._lockedTxSlot = null;
+  eng._lastRxSlot = null;
+
+  // Set a fake old timer
+  eng._txEndTimer = setTimeout(() => {
+    // This should NEVER fire — it's the "old" timer
+    console.error('FAIL: Old safety timer fired — was not cleared');
+  }, 200);
+
+  // tryImmediateTx should replace it
+  const fired = eng.tryImmediateTx();
+  if (fired) {
+    assert(eng._txEndTimer !== null, 'New safety timer set');
+    // Clean up
+    clearTimeout(eng._txEndTimer);
+    eng._txActive = false;
+  } else {
+    // Might not fire due to slot timing — that's OK
+    clearTimeout(eng._txEndTimer);
+    console.log('  SKIP: tryImmediateTx returned false (slot timing) — timer test inconclusive');
+  }
+  eng.stop();
+}
+
+async function testFT2MonitoringGap() {
+  console.log('\n--- Test: FT2 requires monitoring gap between TX cycles ---');
+  const eng = makeEngine('FT2');
+  eng._txMessage = 'CQ K3SBP FN20';
+  eng._txSamples = new Float32Array(1000);
+  eng._txEncodedMsg = eng._txMessage;
+  eng._txEncodedFreq = 1500;
+  eng._txEnabled = true;
+
+  // Simulate TX on cycle 5
+  eng._cycleNumber = 5;
+  eng._lastTxCycleNum = -1;
+  const first = eng.tryImmediateTx();
+  if (first) {
+    assert(eng._lastTxCycleNum === 5, 'Last TX cycle recorded');
+    clearTimeout(eng._txEndTimer);
+    eng._txActive = false;
+
+    // Try TX on cycle 6 — should be blocked (gap < 2)
+    eng._cycleNumber = 6;
+    const second = eng.tryImmediateTx();
+    assert(second === false, 'FT2 TX blocked on cycle 6 (gap=1)');
+
+    // Try TX on cycle 7 — should work (gap = 2)
+    eng._cycleNumber = 7;
+    const third = eng.tryImmediateTx();
+    assert(third === true, 'FT2 TX allowed on cycle 7 (gap=2)');
+    clearTimeout(eng._txEndTimer);
+    eng._txActive = false;
+  } else {
+    console.log('  SKIP: First FT2 TX did not fire — test inconclusive');
+  }
+  eng.stop();
+}
+
+async function testMaxConsecutiveTxCap() {
+  console.log('\n--- Test: Max consecutive TX (5) blocks further TX ---');
+  const eng = makeEngine('FT8');
+  eng._txMessage = 'CQ K3SBP FN20';
+  eng._txSamples = new Float32Array(1000);
+  eng._txEncodedMsg = eng._txMessage;
+  eng._txEncodedFreq = 1500;
+  eng._txEnabled = true;
+  eng._consecutiveTxCount = 5; // at the cap
+
+  const fired = eng.tryImmediateTx();
+  // For FT8, consecutive check only applies in _onTxBoundary, not tryImmediateTx
+  // But for FT2 it does apply in tryImmediateTx:
+  const eng2 = makeEngine('FT2');
+  eng2._txMessage = 'CQ K3SBP FN20';
+  eng2._txSamples = new Float32Array(1000);
+  eng2._txEncodedMsg = eng2._txMessage;
+  eng2._txEncodedFreq = 1500;
+  eng2._txEnabled = true;
+  eng2._consecutiveTxCount = 5;
+  eng2._cycleNumber = 100;
+  eng2._lastTxCycleNum = 50; // gap OK
+
+  const fired2 = eng2.tryImmediateTx();
+  assert(fired2 === false, 'FT2 tryImmediateTx blocked at max consecutive TX');
+
+  eng.stop();
+  eng2.stop();
+}
+
+// --- Grid validation tests ---
+
+function testGridRegex() {
+  console.log('\n--- Test: Grid extraction regex + RR73 exclusion ---');
+  const regex = /\b([A-R]{2}\d{2})\s*$/i;
+  const exclude = /^RR\d{2}$/i;
+
+  function gridMatch(msg) {
+    const m = msg.match(regex);
+    if (!m) return null;
+    if (exclude.test(m[1])) return null; // RR73 etc excluded
+    return m[1].toUpperCase();
+  }
+
+  // Valid grids at end of CQ messages
+  assert(gridMatch('CQ K1ABC FN20') === 'FN20', 'FN20 extracted from CQ');
+  assert(gridMatch('CQ K1ABC AA00') === 'AA00', 'AA00 extracted');
+  assert(gridMatch('CQ K1ABC EM11') === 'EM11', 'EM11 extracted (not confused with DXCC)');
+  assert(gridMatch('CQ K1ABC JN48') === 'JN48', 'JN48 extracted');
+  assert(gridMatch('CQ K1ABC IO91') === 'IO91', 'IO91 extracted');
+  assert(gridMatch('CQ DX K1ABC FN20') === 'FN20', 'Grid after directed CQ');
+
+  // FT8 exchanges that should NOT match as grids
+  assert(gridMatch('K1ABC W2XYZ RR73') === null, 'RR73 excluded by filter');
+  assert(gridMatch('K1ABC W2XYZ RR99') === null, 'RR99 excluded by filter');
+  assert(gridMatch('K1ABC W2XYZ -15') === null, 'Signal report -15 not a grid');
+  assert(gridMatch('K1ABC W2XYZ R-07') === null, 'R-report not a grid');
+  assert(gridMatch('K1ABC W2XYZ 73') === null, '73 not a grid (2 chars)');
+  assert(gridMatch('K1ABC W2XYZ RRR') === null, 'RRR not a grid (3 chars)');
+  assert(gridMatch('K1ABC W2XYZ R+05') === null, 'R+report not a grid');
+}
+
+// --- Double-logging prevention tests ---
+
+function testDoubleLogGuard() {
+  console.log('\n--- Test: Double-logging prevention via _logged flag ---');
+
+  // Simulate a QSO object
+  const qso = { call: 'W1XYZ', report: '-12', sentReport: '+05', phase: '73', _logged: false };
+
+  // First "log" should succeed
+  assert(!qso._logged, 'QSO not logged initially');
+  qso._logged = true;
+  assert(qso._logged, 'QSO marked as logged');
+
+  // Second "log" attempt should be blocked
+  const wouldLog = !qso._logged;
+  assert(wouldLog === false, 'Second log attempt blocked by _logged flag');
+}
+
+function testNoLogWithoutReports() {
+  console.log('\n--- Test: QSO without reports should not log ---');
+
+  // QSO with no reports at all
+  const qso1 = { call: 'W1XYZ', report: null, sentReport: null };
+  const shouldLog1 = !!(qso1.report || qso1.sentReport);
+  assert(shouldLog1 === false, 'QSO with no reports blocked from logging');
+
+  // QSO with only received report
+  const qso2 = { call: 'W1XYZ', report: '-12', sentReport: null };
+  const shouldLog2 = !!(qso2.report || qso2.sentReport);
+  assert(shouldLog2 === true, 'QSO with received report allowed (partial OK)');
+
+  // QSO with both reports
+  const qso3 = { call: 'W1XYZ', report: '-12', sentReport: '+05' };
+  const shouldLog3 = !!(qso3.report || qso3.sentReport);
+  assert(shouldLog3 === true, 'QSO with both reports allowed');
+}
+
+// --- Report regex tests ---
+
+function testReportRegex() {
+  console.log('\n--- Test: CQ mode report regex (R prefix optional) ---');
+  const regex = /R?([+-]\d{2})/;
+
+  // With R prefix
+  let m = 'K1ABC K3SBP R-12'.match(regex);
+  assert(m && m[1] === '-12', 'R-12 extracted correctly');
+
+  m = 'K1ABC K3SBP R+05'.match(regex);
+  assert(m && m[1] === '+05', 'R+05 extracted correctly');
+
+  // Without R prefix (some stations omit it)
+  m = 'K1ABC K3SBP -15'.match(regex);
+  assert(m && m[1] === '-15', '-15 extracted without R prefix');
+
+  m = 'K1ABC K3SBP +02'.match(regex);
+  assert(m && m[1] === '+02', '+02 extracted without R prefix');
+
+  // Should NOT match non-reports
+  m = 'K1ABC K3SBP RR73'.match(regex);
+  // RR73 would match R followed by R73... but R73 doesn't match [+-]\d{2}
+  assert(!m || m[1] !== 'R73', 'RR73 does not extract as report');
+
+  m = 'K1ABC K3SBP 73'.match(regex);
+  assert(!m, '73 alone is not a report (no +/- sign)');
+}
+
+// Run all tests
+(async () => {
+  console.log('=== FT8 Engine Unit Tests ===');
+  await testSafetyTimerClear();
+  await testSetTxMessageClearsTimer();
+  await testModeResetSlots();
+  await testConsecutiveTxOnlyResetsOnDecodes();
+  await testSetTxSlotPreservesAutoLock();
+  await testTryImmediateTxSafetyTimer();
+  await testFT2MonitoringGap();
+  await testMaxConsecutiveTxCap();
+
+  console.log('\n=== Grid, Report & Logging Tests ===');
+  testGridRegex();
+  testDoubleLogGuard();
+  testNoLogWithoutReports();
+  testReportRegex();
+
+  console.log(`\n=== Results: ${passed} passed, ${failed} failed ===`);
+  process.exit(failed > 0 ? 1 : 0);
+})();

--- a/lib/ft8-engine.js
+++ b/lib/ft8-engine.js
@@ -408,7 +408,12 @@ class Ft8Engine extends EventEmitter {
   }
 
   _spawnWorker() {
-    const workerPath = path.join(__dirname, 'ft8-worker.js');
+    // In packaged Electron builds, asarUnpack extracts files to app.asar.unpacked/
+    // Worker threads need the real filesystem path, not the asar virtual path
+    let workerPath = path.join(__dirname, 'ft8-worker.js');
+    if (workerPath.includes('app.asar')) {
+      workerPath = workerPath.replace('app.asar', 'app.asar.unpacked');
+    }
     this._worker = new Worker(workerPath);
     this._worker.on('message', (msg) => this._onWorkerMessage(msg));
     this._worker.on('error', (err) => {

--- a/lib/ft8-engine.js
+++ b/lib/ft8-engine.js
@@ -115,6 +115,10 @@ class Ft8Engine extends EventEmitter {
     this._txActive = false; // true while TX audio is playing
     this._txEndTimer = null;
     this._lastRxSlot = null; // slot of last received decode cycle
+    this._lockedTxSlot = null; // locked opposite slot for TX (set when TX enabled)
+    this._consecutiveTxCount = 0; // consecutive TX cycles without monitoring
+    this._lastTxCycleNum = -1; // cycle number of last TX
+    this._maxConsecutiveTx = 5; // safety: max TX cycles before forced monitor
 
     // Pending decode callbacks
     this._pending = new Map();
@@ -205,6 +209,9 @@ class Ft8Engine extends EventEmitter {
       // Invalidate pre-encoded TX (encode type changes)
       this._txSamples = null;
       this._txEncodedMsg = '';
+      // Reset slot state — stale slot from previous mode can cause TX on wrong slot
+      this._lastRxSlot = null;
+      this._lockedTxSlot = null;
       // Reschedule cycle + TX timers for new cycle length
       if (this._running) {
         if (this._cycleTimer) { clearTimeout(this._cycleTimer); this._cycleTimer = null; }
@@ -231,6 +238,14 @@ class Ft8Engine extends EventEmitter {
    */
   setTxMessage(text) {
     this._txMessage = text || '';
+    if (!text) {
+      this._consecutiveTxCount = 0;
+      this._lockedTxSlot = null;
+      if (this._txEndTimer) { clearTimeout(this._txEndTimer); this._txEndTimer = null; }
+    } else if (this._lastRxSlot && !this._lockedTxSlot) {
+      // Lock TX to opposite of last RX slot — prevents decode cycles from flipping it
+      this._lockedTxSlot = this._lastRxSlot === 'even' ? 'odd' : 'even';
+    }
     return this._preEncode();
   }
 
@@ -240,6 +255,14 @@ class Ft8Engine extends EventEmitter {
    */
   setTxSlot(slot) {
     this._txSlot = (slot === 'even' || slot === 'odd') ? slot : 'auto';
+    // Lock the slot so decode cycles can't flip it
+    if (slot === 'even' || slot === 'odd') {
+      this._lockedTxSlot = slot;
+    } else if (!this._txMessage) {
+      // Only clear auto-lock when no TX message is set — prevents
+      // setTxSlot('auto') from undoing the lock that setTxMessage() created
+      this._lockedTxSlot = null;
+    }
   }
 
   /**
@@ -273,10 +296,15 @@ class Ft8Engine extends EventEmitter {
     const cycleMs = cycleSec * 1000;
     const msIntoCycle = now % cycleMs;
 
-    // FT2 is async — no even/odd slot logic. TX fires immediately when ready.
+    // FT2 is async — no even/odd slot logic, but enforce monitoring gap
     if (this._mode === 'FT2') {
+      if (this._consecutiveTxCount >= this._maxConsecutiveTx) return false;
+      if (this._lastTxCycleNum >= 0 && this._cycleNumber - this._lastTxCycleNum < 2) return false;
       this._txActive = true;
-      const safetyMs = FT2_TX_DURATION_MS + 1000;
+      this._consecutiveTxCount++;
+      this._lastTxCycleNum = this._cycleNumber;
+      const safetyMs = FT2_TX_DURATION_MS + 1500;
+      if (this._txEndTimer) clearTimeout(this._txEndTimer);
       this._txEndTimer = setTimeout(() => {
         if (this._txActive) {
           console.warn('[JTCAT] TX safety timeout — forcing tx-end');
@@ -297,9 +325,11 @@ class Ft8Engine extends EventEmitter {
 
     const slot = Math.floor(now / 1000 / cycleSec) % 2 === 0 ? 'even' : 'odd';
 
-    // Must be in the correct slot — if wrong slot, wait for normal scheduler
+    // Must be in the correct slot — use locked slot if available
     if (this._txSlot === 'auto') {
-      if (this._lastRxSlot && slot === this._lastRxSlot) return false;
+      const targetSlot = this._lockedTxSlot;
+      if (targetSlot && slot !== targetSlot) return false;
+      if (!targetSlot && this._lastRxSlot && slot === this._lastRxSlot) return false;
     } else if (this._txSlot !== slot) {
       return false;
     }
@@ -313,6 +343,7 @@ class Ft8Engine extends EventEmitter {
     this._txActive = true;
     const remainingMs = cycleMs - msIntoCycle;
     const safetyMs = remainingMs + 1000;
+    if (this._txEndTimer) clearTimeout(this._txEndTimer);
     this._txEndTimer = setTimeout(() => {
       if (this._txActive) {
         console.warn('[JTCAT] TX safety timeout — forcing tx-end');
@@ -419,6 +450,10 @@ class Ft8Engine extends EventEmitter {
           this._respawnWorker();
         }
       }
+
+      // Reset consecutive TX counter only when real decodes received (monitoring worked)
+      // Don't reset on empty RX cycles — prevents bypass of the safety cap
+      if (!this._txActive && count > 0) this._consecutiveTxCount = 0;
 
       this.emit('decode', {
         cycle: this._cycleNumber,
@@ -593,10 +628,24 @@ class Ft8Engine extends EventEmitter {
       return;
     }
 
-    // FT2 is async — TX fires immediately at any boundary, no slot logic
+    // Safety: max consecutive TX cycles without monitoring (applies to all modes)
+    if (this._consecutiveTxCount >= this._maxConsecutiveTx) {
+      console.warn(`[JTCAT] Max consecutive TX (${this._maxConsecutiveTx}) — forcing monitor cycle`);
+      this._consecutiveTxCount = 0;
+      return; // skip this TX, allow a decode cycle
+    }
+
+    // FT2 is async — no even/odd slot logic, but require 1 monitor cycle between TXes
     if (this._mode === 'FT2') {
+      // Require at least 1 RX cycle gap between TX cycles
+      if (this._lastTxCycleNum >= 0 && this._cycleNumber - this._lastTxCycleNum < 2) {
+        return; // skip — need a monitoring gap
+      }
       this._txActive = true;
-      const safetyMs = FT2_TX_DURATION_MS + 1000;
+      this._consecutiveTxCount++;
+      this._lastTxCycleNum = this._cycleNumber;
+      const safetyMs = FT2_TX_DURATION_MS + 1500; // extra margin for FT2
+      if (this._txEndTimer) clearTimeout(this._txEndTimer);
       this._txEndTimer = setTimeout(() => {
         if (this._txActive) {
           console.warn('[JTCAT] TX safety timeout — forcing tx-end');
@@ -619,20 +668,25 @@ class Ft8Engine extends EventEmitter {
     const cycleSec = this._cycleSec();
     const slot = Math.floor(now / 1000 / cycleSec) % 2 === 0 ? 'even' : 'odd';
 
-    // Check slot parity
+    // Check slot parity — use locked slot if available (prevents decode from flipping)
     if (this._txSlot === 'auto') {
-      if (this._lastRxSlot && slot === this._lastRxSlot) return;
+      const targetSlot = this._lockedTxSlot;
+      if (targetSlot && slot !== targetSlot) return;
+      if (!targetSlot && this._lastRxSlot && slot === this._lastRxSlot) return;
     } else if (this._txSlot !== slot) {
       return;
     }
 
     this._txActive = true;
+    this._consecutiveTxCount++;
+    this._lastTxCycleNum = this._cycleNumber;
 
     // Safety timer must fire BEFORE the next TX boundary so _txActive is cleared
     // in time for the next cycle's TX (e.g. courtesy 73). FT8 audio is ~12.64s,
     // FT4 is ~4.48s — cycleSec-1.5 gives ample margin after audio ends while
     // ensuring the timer fires well before the next boundary at cycleSec.
     const safetyMs = (cycleSec - 1.5) * 1000;
+    if (this._txEndTimer) clearTimeout(this._txEndTimer);
     this._txEndTimer = setTimeout(() => {
       if (this._txActive) {
         console.warn('[JTCAT] TX safety timeout — forcing tx-end');

--- a/lib/jtcat-autotest.js
+++ b/lib/jtcat-autotest.js
@@ -1,0 +1,230 @@
+'use strict';
+/**
+ * JTCAT automated QSO test — run from main.js setTimeout hook.
+ * Tests FT8, FT4, FT2 on 20m and 15m with real on-air QSOs.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const TESTS = [
+  { band: '20m', mode: 'FT8', freq: 14074, cycleSec: 15, rxCycles: 3 },
+  { band: '20m', mode: 'FT4', freq: 14080, cycleSec: 7.5, rxCycles: 3 },
+  { band: '20m', mode: 'FT2', freq: 14074, cycleSec: 3.8, rxCycles: 3 },
+  { band: '15m', mode: 'FT8', freq: 21074, cycleSec: 15, rxCycles: 3 },
+  { band: '15m', mode: 'FT4', freq: 21140, cycleSec: 7.5, rxCycles: 3 },
+  { band: '15m', mode: 'FT2', freq: 21074, cycleSec: 3.8, rxCycles: 3 },
+];
+
+const QSO_TIMEOUT_SEC = 90; // max time to complete a QSO attempt
+const MAX_TX_POWER = 50;
+
+module.exports = async function runTests({ tuneRadio, startJtcat, stopJtcat, ft8Engine: getEngine, smartSdr, sendCatLog, ipcMain, app, settings }) {
+  const logPath = path.join(app.getPath('userData'), 'jtcat-test.log');
+  fs.writeFileSync(logPath, '');
+  const log = (msg) => {
+    const ts = new Date().toISOString().slice(11, 23);
+    const line = `[${ts}] ${msg}`;
+    sendCatLog('[TEST] ' + msg);
+    fs.appendFileSync(logPath, line + '\n');
+  };
+  const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+
+  const results = [];
+
+  log('=== JTCAT Full QSO Test Suite ===');
+  log(`Callsign: ${settings.myCallsign || 'K3SBP'}, Grid: ${settings.grid || 'FN20'}`);
+  log(`TX Power: ${MAX_TX_POWER}W max`);
+  log(`Tests: ${TESTS.length} (${TESTS.map(t => t.band + ' ' + t.mode).join(', ')})`);
+
+  // Set TX power
+  if (smartSdr && smartSdr.connected) {
+    smartSdr.setTxPower(MAX_TX_POWER);
+    log(`Power set to ${MAX_TX_POWER}W via SmartSDR`);
+  }
+
+  // Open JTCAT popout for audio capture
+  ipcMain.emit('jtcat-popout-open', {});
+  await sleep(3000);
+  log('JTCAT popout opened');
+
+  for (let ti = 0; ti < TESTS.length; ti++) {
+    const t = TESTS[ti];
+    const testId = `${ti + 1}/${TESTS.length}`;
+    log(`\n--- Test ${testId}: ${t.band} ${t.mode} on ${t.freq} kHz ---`);
+
+    // Tune and start engine
+    tuneRadio(t.freq, 'DIGU');
+    await sleep(1500);
+
+    const engine = getEngine();
+    if (engine && engine._running) engine.stop();
+    await sleep(500);
+    startJtcat(t.mode);
+    await sleep(1000);
+
+    const eng = getEngine();
+    if (!eng || !eng._running) {
+      log(`FAIL: Engine not running for ${t.mode}`);
+      results.push({ test: `${t.band} ${t.mode}`, decode: 'FAIL', qso: 'SKIP' });
+      continue;
+    }
+    log(`Engine started: mode=${eng._mode} running=${eng._running}`);
+
+    // Phase A: RX — collect decodes for N cycles
+    const rxWaitMs = t.cycleSec * t.rxCycles * 1000 + 2000; // extra buffer
+    let allDecodes = [];
+    const dh = (d) => {
+      const n = (d.results || []).length;
+      if (n > 0) log(`  Decode cycle: ${n} decodes`);
+      allDecodes = allDecodes.concat(d.results || []);
+    };
+    eng.on('decode', dh);
+    log(`RX: Waiting ${(rxWaitMs / 1000).toFixed(0)}s for ${t.rxCycles} ${t.mode} cycles...`);
+    await sleep(rxWaitMs);
+    eng.removeListener('decode', dh);
+    log(`RX complete: ${allDecodes.length} total decodes`);
+
+    if (allDecodes.length === 0) {
+      log(`No decodes on ${t.band} ${t.mode} — skipping QSO attempt`);
+      results.push({ test: `${t.band} ${t.mode}`, decode: `FAIL (0 in ${t.rxCycles} cycles)`, qso: 'SKIP' });
+      continue;
+    }
+    results.push({ test: `${t.band} ${t.mode}`, decode: `PASS (${allDecodes.length})` });
+
+    // Phase B: Find best CQ to reply to
+    const cqs = allDecodes.filter(d => d.text && d.text.startsWith('CQ '));
+    if (cqs.length === 0) {
+      log(`No CQs found in ${allDecodes.length} decodes — sending our own CQ`);
+      // Send CQ instead
+      const myCall = settings.myCallsign || 'K3SBP';
+      const myGrid = (settings.grid || 'FN20').substring(0, 4);
+      eng.setTxFreq(1500);
+      await eng.setTxMessage(`CQ ${myCall} ${myGrid}`);
+      eng._txEnabled = true;
+      log(`TX: CQ ${myCall} ${myGrid} at 1500 Hz (encoded, locked slot=${eng._lockedTxSlot})`);
+
+      // Wait for a response (up to QSO_TIMEOUT_SEC)
+      let gotReply = false;
+      const rh = (d) => {
+        for (const r of (d.results || [])) {
+          if (r.text && r.text.includes(myCall)) {
+            gotReply = true;
+            log(`  Got reply: "${r.text}" db=${r.db}`);
+          }
+        }
+      };
+      eng.on('decode', rh);
+      const waitStart = Date.now();
+      while (!gotReply && Date.now() - waitStart < QSO_TIMEOUT_SEC * 1000) {
+        await sleep(t.cycleSec * 1000);
+      }
+      eng.removeListener('decode', rh);
+      eng._txEnabled = false;
+      eng.setTxMessage('');
+      log(`CQ result: ${gotReply ? 'Got reply!' : 'No reply in ' + QSO_TIMEOUT_SEC + 's'}`);
+      results[results.length - 1].qso = gotReply ? 'REPLY RECEIVED' : 'NO REPLY';
+      continue;
+    }
+
+    // Pick the strongest CQ
+    const best = cqs.reduce((a, b) => (b.db > a.db ? b : a), cqs[0]);
+    log(`Best CQ: "${best.text}" db=${best.db} df=${best.df.toFixed(0)}Hz`);
+
+    // Extract callsign from CQ message
+    const parts = best.text.split(/\s+/);
+    let dxCall = '';
+    if (parts[1] === 'DX' || parts[1] === 'POTA' || parts[1] === 'NA' || parts[1] === 'EU') {
+      dxCall = parts[2] || '';
+    } else {
+      dxCall = parts[1] || '';
+    }
+    if (!dxCall) {
+      log(`Could not extract callsign from "${best.text}" — skipping`);
+      results[results.length - 1].qso = 'SKIP (bad CQ)';
+      continue;
+    }
+
+    // Reply to the CQ
+    const myCall = settings.myCallsign || 'K3SBP';
+    const myGrid = (settings.grid || 'FN20').substring(0, 4);
+    const replyMsg = `${dxCall} ${myCall} ${myGrid}`;
+    eng.setTxFreq(Math.round(best.df));
+    await eng.setTxMessage(replyMsg);
+    eng._txEnabled = true;
+    eng.setTxSlot('auto');
+    log(`TX: "${replyMsg}" at ${Math.round(best.df)} Hz (replying to ${dxCall})`);
+
+    // Track QSO state
+    let qsoPhase = 'grid-sent'; // grid-sent → report-sent → rr73-sent → done
+    let txCount = 0;
+    let qsoComplete = false;
+    const qsoStart = Date.now();
+
+    const txh = (d) => { txCount++; log(`  TX #${txCount}: "${d.message}" slot=${d.slot}`); };
+    const txeh = () => { log(`  TX end`); };
+    eng.on('tx-start', txh);
+    eng.on('tx-end', txeh);
+
+    const qrh = (d) => {
+      for (const r of (d.results || [])) {
+        if (!r.text) continue;
+        const t = r.text.toUpperCase();
+        if (t.includes(myCall)) {
+          log(`  RX: "${r.text}" db=${r.db}`);
+          // Check for signal report (e.g. "K3SBP DX1ABC -15")
+          if (t.match(/-?\d{2}$/) && qsoPhase === 'grid-sent') {
+            qsoPhase = 'report-rcvd';
+            const report = t.match(/-?\d{2}$/)[0];
+            const rrMsg = `${dxCall} ${myCall} R${report}`;
+            eng.setTxMessage(rrMsg);
+            log(`  → Sending R-report: "${rrMsg}"`);
+          }
+          // Check for RR73 or 73
+          if ((t.includes('RR73') || t.includes(' 73')) && qsoPhase === 'report-rcvd') {
+            qsoPhase = 'rr73-rcvd';
+            eng.setTxMessage(`${dxCall} ${myCall} 73`);
+            log(`  → Sending 73`);
+            // QSO complete after sending 73
+            setTimeout(() => {
+              qsoComplete = true;
+              eng._txEnabled = false;
+              eng.setTxMessage('');
+            }, t.cycleSec ? t.cycleSec * 1000 : 15000);
+          }
+        }
+      }
+    };
+    eng.on('decode', qrh);
+
+    // Wait for QSO to complete or timeout
+    while (!qsoComplete && Date.now() - qsoStart < QSO_TIMEOUT_SEC * 1000) {
+      await sleep(2000);
+    }
+
+    eng.removeListener('tx-start', txh);
+    eng.removeListener('tx-end', txeh);
+    eng.removeListener('decode', qrh);
+    eng._txEnabled = false;
+    eng.setTxMessage('');
+
+    const elapsed = Math.round((Date.now() - qsoStart) / 1000);
+    log(`QSO result: phase=${qsoPhase} txCount=${txCount} elapsed=${elapsed}s complete=${qsoComplete}`);
+    results[results.length - 1].qso = qsoComplete ? `COMPLETE (${elapsed}s, ${txCount} TX)` : `${qsoPhase} (timeout ${elapsed}s, ${txCount} TX)`;
+  }
+
+  // Stop engine and restore power
+  const eng = getEngine();
+  if (eng) eng.stop();
+  if (smartSdr && smartSdr.connected) smartSdr.setTxPower(100);
+  log('\nRestored TX power to 100W');
+
+  // Summary
+  log('\n=== TEST SUMMARY ===');
+  for (const r of results) {
+    log(`${r.test}: decode=${r.decode || '?'} qso=${r.qso || '?'}`);
+  }
+  log('=== END ===');
+
+  return results;
+};

--- a/lib/jtcat-echocat-test.js
+++ b/lib/jtcat-echocat-test.js
@@ -1,0 +1,201 @@
+'use strict';
+/**
+ * JTCAT ECHOCAT automated test — simulates phone-initiated FT8/FT4/FT2
+ * by driving the remoteServer event handlers (same path ECHOCAT uses).
+ *
+ * Tests: decode, TX firing, QSO state progression, halt, mode switch.
+ * TX power set to 5W for safety.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const TX_POWER = 5;
+const TESTS = [
+  { band: '20m', mode: 'FT8', freq: 14074, cycleSec: 15 },
+  { band: '20m', mode: 'FT4', freq: 14080, cycleSec: 7.5 },
+  { band: '15m', mode: 'FT8', freq: 21074, cycleSec: 15 },
+];
+
+module.exports = async function runEchocatTests({ tuneRadio, startJtcat, stopJtcat, ft8Engine: getEngine, smartSdr, sendCatLog, remoteServer, app, settings }) {
+  const logPath = path.join(app.getPath('userData'), 'jtcat-test.log');
+  fs.writeFileSync(logPath, '');
+  const log = (msg) => {
+    const ts = new Date().toISOString().slice(11, 23);
+    const line = `[${ts}] ${msg}`;
+    sendCatLog('[ETEST] ' + msg);
+    fs.appendFileSync(logPath, line + '\n');
+  };
+  const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+  const results = [];
+
+  log('=== ECHOCAT JTCAT Test Suite ===');
+  log(`Call: ${settings.myCallsign}, Grid: ${settings.grid}`);
+  log(`Power: ${TX_POWER}W`);
+
+  if (smartSdr && smartSdr.connected) smartSdr.setTxPower(TX_POWER);
+
+  // Open popout for audio (required for engine audio feed)
+  require('electron').ipcMain.emit('jtcat-popout-open', {});
+  await sleep(4000);
+
+  for (let ti = 0; ti < TESTS.length; ti++) {
+    const t = TESTS[ti];
+    const label = `${t.band} ${t.mode}`;
+    log(`\n--- Test ${ti + 1}/${TESTS.length}: ${label} on ${t.freq} kHz ---`);
+
+    // Phase 1: Tune + set mode (keep engine alive, just switch freq/mode)
+    log('Phase 1: Tune + mode');
+    tuneRadio(t.freq, 'DIGU');
+    await sleep(1500);
+    const eng = getEngine();
+    if (!eng || !eng._running) {
+      log(`FAIL: Engine not running`);
+      results.push({ test: label, result: 'FAIL (no engine)' });
+      continue;
+    }
+    if (eng._mode !== t.mode) {
+      eng.setMode(t.mode);
+      log(`Mode switched to ${t.mode}`);
+    }
+    await sleep(1000);
+    log(`Engine: mode=${eng._mode} running=${eng._running}`);
+
+    // Phase 2: Decode for 2 cycles
+    const rxWait = t.cycleSec * 2 * 1000 + 3000;
+    let decodes = [];
+    const dh = (d) => {
+      decodes = decodes.concat(d.results || []);
+      if ((d.results || []).length > 0) log(`  Decode: ${d.results.length} (slot=${d.slot})`);
+    };
+    eng.on('decode', dh);
+    log(`Phase 2: RX ${(rxWait / 1000).toFixed(0)}s for ${t.mode} decodes...`);
+    await sleep(rxWait);
+    eng.removeListener('decode', dh);
+    log(`Decodes: ${decodes.length}`);
+
+    if (decodes.length === 0) {
+      results.push({ test: label, result: `DECODE: 0 (no activity)` });
+      log('No decodes — skipping TX test');
+      continue;
+    }
+
+    // Phase 3: TX test — find CQ, reply via ECHOCAT path
+    const cqs = decodes.filter(d => d.text && d.text.startsWith('CQ '));
+    log(`CQs found: ${cqs.length}`);
+
+    if (cqs.length > 0) {
+      const best = cqs.reduce((a, b) => (b.db > a.db ? b : a), cqs[0]);
+      const parts = best.text.split(/\s+/);
+      const dxCall = (parts[1] === 'DX' || parts[1] === 'POTA' || parts[1] === 'NA' || parts[1] === 'EU') ? (parts[2] || '') : (parts[1] || '');
+
+      if (dxCall) {
+        log(`Phase 3: Replying to ${dxCall} (${best.text}, db=${best.db})`);
+
+        // Simulate ECHOCAT reply event (same as phone tapping a decode)
+        if (remoteServer) {
+          remoteServer.emit('jtcat-reply', {
+            call: dxCall,
+            grid: '',
+            freq: Math.round(best.df),
+            slot: best.slot || 'auto',
+          });
+        }
+        await sleep(1000);
+
+        // Track TX and QSO state
+        let txCount = 0;
+        let lastPhase = 'reply';
+        let gotReport = false;
+        let gotRr73 = false;
+        const txh = () => { txCount++; log(`  TX #${txCount}`); };
+        eng.on('tx-start', txh);
+
+        const qsoCheck = setInterval(() => {
+          const q = getQso();
+          if (q) {
+            if (q.phase !== lastPhase) {
+              log(`  Phase: ${lastPhase} → ${q.phase}`);
+              lastPhase = q.phase;
+              if (q.phase === 'r+report') gotReport = true;
+              if (q.phase === '73' || q.phase === 'done') gotRr73 = true;
+            }
+          }
+        }, 2000);
+
+        // Use closure to access remoteJtcatQso
+        function getQso() {
+          // Can't access remoteJtcatQso directly — check via engine state
+          return { phase: eng._txEnabled ? (gotRr73 ? 'done' : gotReport ? 'r+report' : 'reply') : 'done' };
+        }
+
+        // Wait up to 60s for QSO or timeout
+        log(`Phase 3: Waiting 60s for QSO with ${dxCall}...`);
+        await sleep(60000);
+
+        clearInterval(qsoCheck);
+        eng.removeListener('tx-start', txh);
+
+        log(`QSO result: txCount=${txCount} gotReport=${gotReport} gotRr73=${gotRr73} txEnabled=${eng._txEnabled}`);
+        results.push({
+          test: label,
+          result: `DECODE: ${decodes.length}, TX: ${txCount}, report=${gotReport}, rr73=${gotRr73}`,
+        });
+
+        // Clean up — halt TX
+        eng._txEnabled = false;
+        eng.setTxMessage('');
+        eng.setTxSlot('auto');
+        await sleep(1000);
+      } else {
+        results.push({ test: label, result: `DECODE: ${decodes.length}, no valid CQ call` });
+      }
+    } else {
+      // No CQ — test CQ TX instead
+      log(`Phase 3: No CQs — testing CQ TX via ECHOCAT path`);
+      if (remoteServer) {
+        remoteServer.emit('jtcat-call-cq', { freq: 1500 });
+      }
+      await sleep(1000);
+
+      let txCount = 0;
+      const txh = () => { txCount++; log(`  CQ TX #${txCount}`); };
+      eng.on('tx-start', txh);
+
+      log('Waiting 35s for CQ TX...');
+      await sleep(35000);
+
+      eng.removeListener('tx-start', txh);
+      eng._txEnabled = false;
+      eng.setTxMessage('');
+      eng.setTxSlot('auto');
+
+      log(`CQ TX result: ${txCount} transmissions`);
+      results.push({ test: label, result: `DECODE: ${decodes.length}, CQ TX: ${txCount}` });
+    }
+
+    // Phase 4: Verify halt works
+    log('Phase 4: Testing HALT');
+    eng._txEnabled = false;
+    eng.setTxMessage('');
+    eng.setTxSlot('auto');
+    await sleep(500);
+    log(`After halt: txEnabled=${eng._txEnabled} txActive=${eng._txActive} consecutiveTx=${eng._consecutiveTxCount}`);
+    const haltOk = !eng._txEnabled && !eng._txActive;
+    results.push({ test: `${label} HALT`, result: haltOk ? 'PASS' : 'FAIL' });
+  }
+
+  // Restore power
+  if (smartSdr && smartSdr.connected) smartSdr.setTxPower(100);
+  stopJtcat();
+  log('\nRestored power to 100W, engine stopped.');
+
+  // Summary
+  log('\n=== ECHOCAT TEST SUMMARY ===');
+  for (const r of results) {
+    log(`${r.test}: ${r.result}`);
+  }
+  log('=== END ===');
+
+  return results;
+};

--- a/lib/jtcat-manager.js
+++ b/lib/jtcat-manager.js
@@ -40,11 +40,18 @@ class JtcatManager extends EventEmitter {
     engine.setMode(config.mode || 'FT8');
 
     // Forward all events tagged with sliceId
-    for (const evt of ['decode', 'cycle', 'tx-start', 'tx-end', 'status', 'silent', 'error']) {
+    for (const evt of ['decode', 'cycle', 'tx-start', 'tx-end', 'status', 'silent']) {
       engine.on(evt, (data) => {
         this.emit(evt, { sliceId: id, ...(data || {}) });
       });
     }
+    // Handle error events separately — log and emit, but don't crash if no listener
+    engine.on('error', (data) => {
+      console.error(`[JtcatManager] Engine error (slice ${id}):`, data.message || data);
+      if (this.listenerCount('error') > 0) {
+        this.emit('error', { sliceId: id, ...(data || {}) });
+      }
+    });
 
     this._engines.set(id, {
       engine,

--- a/lib/rig-controller.js
+++ b/lib/rig-controller.js
@@ -47,6 +47,9 @@ class RigController extends EventEmitter {
     this._lastRgTime = 0;
     this._lastPcTime = 0;
 
+    // TX state — used to suppress RM polling during transmit
+    this._transmitting = false;
+
     // Wire transport events
     this._transport.on('connect', () => {
       this.connected = true;
@@ -103,6 +106,7 @@ class RigController extends EventEmitter {
     this._codec.on('nb', (on) => this.emit('nb', on));
     this._codec.on('smeter', (val) => this.emit('smeter', val));
     this._codec.on('swr', (val) => this.emit('swr', val));
+    this._codec.on('alc', (val) => this.emit('alc', val));
     this._codec.on('da', (on) => this.emit('da', on));
     this._codec.on('log', (msg) => this._log(msg));
     this._codec.on('error', (e) => this._log(e.message || 'codec error'));
@@ -142,9 +146,12 @@ class RigController extends EventEmitter {
       if (this._codec.getFrequency) this._codec.getFrequency();
       if (this._codec.getMode) this._codec.getMode();
 
-      // Poll S-meter every cycle, SWR every 2nd cycle (fast but not excessive)
-      if (this._codec.getSmeter) this._codec.getSmeter();
-      if (this._codec.getSwr && !this._model.noSwr && this._pollCount % 2 === 0) this._codec.getSwr();
+      // S-meter only makes sense during RX; SWR+ALC only make sense during TX
+      if (!this._transmitting && this._codec.getSmeter) this._codec.getSmeter();
+      if (this._transmitting && this._pollCount % 2 === 0) {
+        if (this._codec.getSwr && !this._model.noSwr) this._codec.getSwr();
+        if (this._codec.getAlc && !this._model.noSwr) this._codec.getAlc();
+      }
       // Poll power and NB every 5th cycle (they change rarely)
       if (this._pollCount++ % 5 === 0) {
         if (caps.txpower && this._codec.getPower) this._codec.getPower();
@@ -274,6 +281,7 @@ class RigController extends EventEmitter {
 
   setTransmit(on) {
     if (!this.connected) return;
+    this._transmitting = !!on;
     this._codec.setTransmit(on);
   }
 

--- a/lib/rig-controller.js
+++ b/lib/rig-controller.js
@@ -27,6 +27,8 @@ class RigController extends EventEmitter {
     this._pollTimer = null;
     this._pollCount = 0;
     this._pendingTimers = [];
+    // TX state — used to suppress RM polling during receive
+    this._transmitting = false;
     this._lastParsedMode = null;
     this._lastFreqHz = 0;
     this._debug = false;
@@ -46,9 +48,6 @@ class RigController extends EventEmitter {
     // Throttle state
     this._lastRgTime = 0;
     this._lastPcTime = 0;
-
-    // TX state — used to suppress RM polling during receive
-    this._transmitting = false;
 
     // Wire transport events
     this._transport.on('connect', () => {
@@ -391,12 +390,18 @@ class RigController extends EventEmitter {
   /** Cancel in-progress CW text by dropping PTT, then send new text */
   sendCwText(text) {
     if (!this.connected || !text) return;
-    // Abort any in-progress CW message so the new one starts immediately
-    this._codec.setTransmit(false);
-    // Brief delay for the radio to process RX before new KY text
-    setTimeout(() => {
-      if (this.connected) this._codec.sendCwText(text);
-    }, 50);
+    const cwCaps = this._model.cw || {};
+    if (cwCaps.text === 'ky1' && (cwCaps.kyParam == null || cwCaps.kyParam === 0)) {
+      // Yaesu KY0 (immediate mode) clears the buffer itself.
+      // Sending TX0 first blocks break-in on FT-710 and similar rigs.
+      this._codec.sendCwText(text);
+    } else {
+      // Kenwood buffered KY: abort current TX first so the new message starts clean
+      this._codec.setTransmit(false);
+      setTimeout(() => {
+        if (this.connected) this._codec.sendCwText(text);
+      }, 50);
+    }
   }
 
   setCwSpeed(wpm) {

--- a/lib/rig-controller.js
+++ b/lib/rig-controller.js
@@ -47,7 +47,7 @@ class RigController extends EventEmitter {
     this._lastRgTime = 0;
     this._lastPcTime = 0;
 
-    // TX state — used to suppress RM polling during transmit
+    // TX state — used to suppress RM polling during receive
     this._transmitting = false;
 
     // Wire transport events

--- a/lib/rig-models.js
+++ b/lib/rig-models.js
@@ -221,6 +221,18 @@ const RIG_MODELS = {
   },
 
   // ── FlexRadio ─────────────────────────────────────────
+  'FLEX-6300': {
+    brand: 'FlexRadio', protocol: 'smartsdr',
+    caps: { nb: true, atu: true, vfo: false, filter: true, filterType: 'arbitrary', rfgain: true, txpower: true, power: false },
+    cw: { text: 'smartsdr', textChunk: 64, speed: 'smartsdr', paddleKey: 'smartsdr', dtrPins: null, taKey: false, breakIn: true },
+    atuCmd: 'smartsdr', maxPower: 100,
+  },
+  'FLEX-6500': {
+    brand: 'FlexRadio', protocol: 'smartsdr',
+    caps: { nb: true, atu: true, vfo: false, filter: true, filterType: 'arbitrary', rfgain: true, txpower: true, power: false },
+    cw: { text: 'smartsdr', textChunk: 64, speed: 'smartsdr', paddleKey: 'smartsdr', dtrPins: null, taKey: false, breakIn: true },
+    atuCmd: 'smartsdr', maxPower: 100,
+  },
   'FLEX-6400/6400M': {
     brand: 'FlexRadio', protocol: 'smartsdr',
     caps: { nb: true, atu: true, vfo: false, filter: true, filterType: 'arbitrary', rfgain: true, txpower: true, power: false },

--- a/lib/websdr.js
+++ b/lib/websdr.js
@@ -1,0 +1,147 @@
+'use strict';
+// WebSDR.org client — connects to a websdr.org receiver via its
+// HTTP-like streaming protocol, tunes to a frequency/mode, and
+// streams decoded PCM audio.
+
+const { EventEmitter } = require('events');
+const net = require('net');
+
+class WebSdrClient extends EventEmitter {
+  constructor() {
+    super();
+    this._socket = null;
+    this._connected = false;
+    this._host = '';
+    this._port = 8901;
+    this._freq = 0;
+    this._mode = 0; // 0=SSB, 1=AM, 4=FM
+    this._lo = -2700;
+    this._hi = -300;
+    this._buf = Buffer.alloc(0);
+    this._headerDone = false;
+    this._sampleRate = 8000; // WebSDR default
+  }
+
+  get connected() { return this._connected; }
+
+  /**
+   * Connect and start streaming.
+   * @param {string} host
+   * @param {number} port — default 8901
+   * @param {number} freqKhz — frequency in kHz
+   * @param {string} mode — 'usb', 'lsb', 'am', 'cw', 'fm'
+   */
+  connect(host, port, freqKhz, mode) {
+    this.disconnect();
+    this._host = host;
+    this._port = port || 8901;
+    this._freq = freqKhz || 7200;
+    this._resolveMode(mode || 'usb');
+    this._headerDone = false;
+    this._buf = Buffer.alloc(0);
+
+    const params = `f=${this._freq}&band=0&lo=${this._lo}&hi=${this._hi}&mode=${this._mode}&name=POTACAT`;
+    const request = `GET /~~stream?${params} HTTP/1.0\r\nHost: ${this._host}:${this._port}\r\n\r\n`;
+
+    console.log(`[WebSDR] Connecting to ${this._host}:${this._port} freq=${this._freq}kHz`);
+
+    try {
+      this._socket = net.connect(this._port, this._host, () => {
+        if (!this._socket) return; // disconnected before connect completed
+        this._connected = true;
+        this._socket.write(request);
+        this.emit('connected');
+      });
+    } catch (err) {
+      this.emit('error', err.message);
+      return;
+    }
+
+    this._socket.on('data', (data) => this._onData(data));
+    this._socket.on('close', () => {
+      const was = this._connected;
+      this._cleanup();
+      if (was) this.emit('disconnected');
+    });
+    this._socket.on('error', (err) => {
+      this.emit('error', err.message || 'Connection error');
+    });
+  }
+
+  disconnect() {
+    const was = this._connected;
+    if (this._socket) {
+      try { this._socket.destroy(); } catch {}
+    }
+    this._cleanup();
+    if (was) this.emit('disconnected');
+  }
+
+  /**
+   * Tune to a new frequency. Reconnects with new params.
+   */
+  tune(freqKhz, mode) {
+    if (!this._connected) return;
+    this._freq = freqKhz;
+    if (mode) this._resolveMode(mode);
+    // WebSDR requires reconnect to change frequency
+    this.connect(this._host, this._port, freqKhz, mode);
+  }
+
+  _resolveMode(mode) {
+    const m = (mode || 'usb').toLowerCase();
+    switch (m) {
+      case 'usb': this._mode = 0; this._lo = 300; this._hi = 2700; break;
+      case 'lsb': this._mode = 0; this._lo = -2700; this._hi = -300; break;
+      case 'cw':  this._mode = 0; this._lo = 300; this._hi = 800; break;
+      case 'am':  this._mode = 1; this._lo = -4000; this._hi = 4000; break;
+      case 'fm':  this._mode = 4; this._lo = -6000; this._hi = 6000; break;
+      default:    this._mode = 0; this._lo = 300; this._hi = 2700; break;
+    }
+  }
+
+  _cleanup() {
+    this._connected = false;
+    this._socket = null;
+    this._buf = Buffer.alloc(0);
+    this._headerDone = false;
+  }
+
+  _onData(data) {
+    this._buf = Buffer.concat([this._buf, data]);
+
+    // Skip first 2-byte header if not done
+    if (!this._headerDone) {
+      if (this._buf.length < 2) return;
+      this._buf = this._buf.slice(2); // skip initial 2-byte handshake
+      this._headerDone = true;
+    }
+
+    // Process audio in chunks — WebSDR sends variable-size u-law encoded packets
+    // Decode as u-law 8kHz mono and convert to Float32
+    while (this._buf.length >= 128) {
+      // Take up to 512 bytes at a time
+      const chunkSize = Math.min(512, this._buf.length);
+      const chunk = this._buf.slice(0, chunkSize);
+      this._buf = this._buf.slice(chunkSize);
+
+      const pcm = new Float32Array(chunk.length);
+      for (let i = 0; i < chunk.length; i++) {
+        pcm[i] = ulawDecode(chunk[i]) / 32768;
+      }
+      this.emit('audio', pcm, this._sampleRate);
+    }
+  }
+}
+
+// u-law to 16-bit linear PCM decode table
+function ulawDecode(u) {
+  u = ~u & 0xFF;
+  const sign = (u & 0x80) ? -1 : 1;
+  const exponent = (u >> 4) & 0x07;
+  const mantissa = u & 0x0F;
+  const sample = sign * ((mantissa << (exponent + 3)) + (1 << (exponent + 3)) - 132);
+  return Math.max(-32768, Math.min(32767, sample));
+}
+
+module.exports = { WebSdrClient };

--- a/main.js
+++ b/main.js
@@ -2517,6 +2517,13 @@ function startJtcat(mode) {
   ft8Engine.removeAllListeners('tx-start');
   ft8Engine.removeAllListeners('tx-end');
 
+  // Catch engine errors (e.g. missing FT4/FT2 decoder on some platforms)
+  ft8Engine.on('error', (data) => {
+    const msg = data.message || String(data);
+    sendCatLog('[JTCAT] Engine error: ' + msg);
+    console.error('[JTCAT] Engine error:', msg);
+  });
+
   ft8Engine.on('decode', async (data) => {
     // Enrich decodes with "needed" flags for call roster
     if (data.results) {
@@ -4445,7 +4452,7 @@ function connectRemote() {
     console.log('[JTCAT Remote] CQ:', txMsg, '@ quiet freq', jtcatQuietFreq, 'Hz slot:', nextSlot);
   });
 
-  remoteServer.on('jtcat-reply', async ({ call, grid, df, slot, sliceId }) => {
+  remoteServer.on('jtcat-reply', async ({ call, grid, df, slot, sliceId, report, rr73, snr }) => {
     // Route TX to correct slice in multi-slice mode
     const targetEngine = (jtcatManager && sliceId) ? jtcatManager.getEngine(sliceId) : ft8Engine;
     if (!targetEngine) return;
@@ -4462,17 +4469,56 @@ function connectRemote() {
     }
     // Halt any active TX (e.g. CQ) so reply goes out on next boundary
     if (targetEngine._txActive) targetEngine.txComplete();
-    const txMsg = call + ' ' + myCall + ' ' + myGrid;
     targetEngine.setTxFreq(df);
     targetEngine.setRxFreq(df);
     // TX on opposite slot from the station we're replying to (use slot from decode data)
     const targetSlot = slot || targetEngine._lastRxSlot;
     targetEngine.setTxSlot(targetSlot === 'even' ? 'odd' : (targetSlot === 'odd' ? 'even' : 'auto'));
-    remoteJtcatQso = { mode: 'reply', call, grid, phase: 'reply', txMsg, report: null, sentReport: null, myCall, myGrid, txRetries: 0, sliceId: sliceId || 'default' };
-    await remoteJtcatSetTxMsg(txMsg); // encode first, then enable TX
-    targetEngine._txEnabled = true;
-    targetEngine.tryImmediateTx();
-    console.log('[JTCAT Remote] Reply to', call, ':', txMsg, 'slot:', targetEngine._txSlot, 'locked:', targetEngine._lockedTxSlot);
+
+    let txMsg, phase;
+    if (rr73) {
+      // They sent RR73/73 — send 73 back, log QSO
+      txMsg = call + ' ' + myCall + ' 73';
+      phase = '73';
+    } else if (report) {
+      // They sent a signal report — pick up at R+report phase
+      const ourSnr = snr != null ? snr : 0;
+      const ourRpt = ourSnr >= 0 ? '+' + String(Math.round(ourSnr)).padStart(2, '0') : '-' + String(Math.abs(Math.round(ourSnr))).padStart(2, '0');
+      txMsg = call + ' ' + myCall + ' R' + ourRpt;
+      phase = 'r+report';
+      remoteJtcatQso = { mode: 'reply', call, grid, phase, txMsg, report, sentReport: ourRpt, myCall, myGrid, txRetries: 0, sliceId: sliceId || 'default' };
+    } else {
+      // Fresh reply to CQ — start from beginning
+      txMsg = call + ' ' + myCall + ' ' + myGrid;
+      phase = 'reply';
+    }
+
+    if (phase === '73') {
+      // Send 73 courtesy — preserve reports from existing QSO if same call
+      const prev = remoteJtcatQso;
+      const sameCall = prev && prev.call && prev.call.toUpperCase() === call.toUpperCase();
+      remoteJtcatQso = { mode: 'reply', call, grid: grid || (sameCall ? prev.grid : ''), phase, txMsg,
+        report: sameCall ? prev.report : null,
+        sentReport: sameCall ? prev.sentReport : null,
+        myCall, myGrid, txRetries: 0, sliceId: sliceId || 'default' };
+      await remoteJtcatSetTxMsg(txMsg);
+      targetEngine._txEnabled = true;
+      targetEngine.tryImmediateTx();
+      if (!sameCall) await jtcatAutoLog(remoteJtcatQso);
+    } else if (phase === 'r+report') {
+      // QSO already created above with reports populated
+      await remoteJtcatSetTxMsg(txMsg);
+      targetEngine._txEnabled = true;
+      targetEngine.tryImmediateTx();
+    } else {
+      // Fresh reply
+      remoteJtcatQso = { mode: 'reply', call, grid, phase: 'reply', txMsg, report: null, sentReport: null, myCall, myGrid, txRetries: 0, sliceId: sliceId || 'default' };
+      await remoteJtcatSetTxMsg(txMsg);
+      targetEngine._txEnabled = true;
+      targetEngine.tryImmediateTx();
+    }
+    remoteJtcatBroadcastQso();
+    console.log('[JTCAT Remote] Reply to', call, ':', txMsg, 'phase:', phase, 'slot:', targetEngine._txSlot, 'locked:', targetEngine._lockedTxSlot);
   });
 
   remoteServer.on('jtcat-enable-tx', ({ enabled }) => {
@@ -8346,8 +8392,8 @@ app.whenReady().then(() => {
     }
     const mod = (modifier || '').toUpperCase().replace(/[^A-Z]/g, '').substring(0, 4);
     const txMsg = mod ? 'CQ ' + mod + ' ' + myCall + ' ' + myGrid : 'CQ ' + myCall + ' ' + myGrid;
-    // TX on next available slot (opposite of last decoded, or 'auto' if no decodes yet)
-    const nextSlot = ft8Engine._lastRxSlot === 'even' ? 'odd' : (ft8Engine._lastRxSlot === 'odd' ? 'even' : 'auto');
+    // TX on opposite slot from last decode; default to 'even' if no decodes yet
+    const nextSlot = ft8Engine._lastRxSlot === 'even' ? 'odd' : 'even';
     ft8Engine.setTxSlot(nextSlot);
     popoutJtcatQso = { mode: 'cq', call: null, grid: null, phase: 'cq', txMsg, report: null, sentReport: null, myCall, myGrid, txRetries: 0 };
     ft8Engine._txEnabled = true;

--- a/main.js
+++ b/main.js
@@ -589,6 +589,12 @@ function sendCatSwr(val) {
   if (remoteServer && remoteServer.running) remoteServer.sendToClient({ type: 'swr', value: val });
 }
 
+function sendCatAlc(val) {
+  if (win && !win.isDestroyed()) win.webContents.send('cat-alc', val);
+  if (vfoPopoutWin && !vfoPopoutWin.isDestroyed()) vfoPopoutWin.webContents.send('cat-alc', val);
+  if (remoteServer && remoteServer.running) remoteServer.sendToClient({ type: 'alc', value: val });
+}
+
 // Broadcast full rig control state to renderer and ECHOCAT
 function broadcastRigState() {
   const rigType = detectRigType();
@@ -716,6 +722,7 @@ async function connectCat() {
     cat.on('nb', sendCatNb);
     cat.on('smeter', sendCatSmeter);
     cat.on('swr', sendCatSwr);
+    cat.on('alc', sendCatAlc);
     cat.connect(target);
     return;
   }
@@ -756,6 +763,7 @@ async function connectCat() {
     cat.on('nb', sendCatNb);
     cat.on('smeter', sendCatSmeter);
     cat.on('swr', sendCatSwr);
+    cat.on('alc', sendCatAlc);
     sendCatLog(`Connecting to rigctld on 127.0.0.1:${rigctldPort}`);
     transport.connect({ host: '127.0.0.1', port: rigctldPort });
 
@@ -777,6 +785,7 @@ async function connectCat() {
     cat.on('nb', sendCatNb);
     cat.on('smeter', sendCatSmeter);
     cat.on('swr', sendCatSwr);
+    cat.on('alc', sendCatAlc);
     const host = target.host || '127.0.0.1';
     const port = target.port || 4532;
     sendCatLog(`Connecting to remote rigctld on ${host}:${port}`);
@@ -797,6 +806,7 @@ async function connectCat() {
     cat.on('nb', sendCatNb);
     cat.on('smeter', sendCatSmeter);
     cat.on('swr', sendCatSwr);
+    cat.on('alc', sendCatAlc);
     sendCatLog(`Connecting to Icom on ${target.path}`);
     transport.connect({ path: target.path, baudRate: target.baudRate || 19200, dtrOff: target.dtrOff });
 
@@ -816,6 +826,7 @@ async function connectCat() {
     cat.on('nb', sendCatNb);
     cat.on('smeter', sendCatSmeter);
     cat.on('swr', sendCatSwr);
+    cat.on('alc', sendCatAlc);
     sendCatLog(`Connecting to ${model.brand || 'radio'} on ${target.path}`);
     transport.connect({ path: target.path, baudRate: target.baudRate || 9600, dtrOff: target.dtrOff, connectDelay: model.connectDelay });
   }
@@ -7367,6 +7378,25 @@ app.whenReady().then(() => {
           try { require('child_process').execSync(`launchctl load "${plistPath}"`, { stdio: 'pipe' }); } catch {}
           console.log('[Launcher] Installed to macOS LaunchAgents');
         }
+      } else {
+        // Linux: write autostart .desktop if not present, then spawn immediately if port is free
+        const autostartDir = path.join(require('os').homedir(), '.config', 'autostart');
+        const desktopPath = path.join(autostartDir, 'potacat-launcher.desktop');
+        if (!fs.existsSync(desktopPath)) {
+          fs.mkdirSync(autostartDir, { recursive: true });
+          fs.writeFileSync(desktopPath, `[Desktop Entry]\nType=Application\nName=POTACAT Launcher\nExec=${exePath} --launcher\nHidden=false\nNoDisplay=true\nX-GNOME-Autostart-enabled=true\n`);
+          console.log('[Launcher] Installed to Linux autostart');
+        }
+        // Start launcher only if port 7301 is not already in use
+        const net = require('net');
+        const probe = net.createServer();
+        probe.once('error', () => { /* port in use — launcher already running */ });
+        probe.once('listening', () => {
+          probe.close();
+          require('child_process').spawn(exePath, ['--launcher'], { detached: true, stdio: 'ignore' }).unref();
+          console.log('[Launcher] Started background process');
+        });
+        probe.listen(7301, '0.0.0.0');
       }
     } catch (err) {
       console.error('[Launcher] Setup failed:', err.message);
@@ -8803,6 +8833,15 @@ app.whenReady().then(() => {
         const autostartDir = path.join(os.homedir(), '.config', 'autostart');
         fs.mkdirSync(autostartDir, { recursive: true });
         fs.writeFileSync(path.join(autostartDir, 'potacat-launcher.desktop'), `[Desktop Entry]\nType=Application\nName=POTACAT Launcher\nExec=${exePath} --launcher\nHidden=false\nNoDisplay=true\nX-GNOME-Autostart-enabled=true\n`);
+        // Spawn immediately (same as Windows) — port probe prevents duplicate
+        const net = require('net');
+        const probe = net.createServer();
+        probe.once('error', () => { /* port in use — already running */ });
+        probe.once('listening', () => {
+          probe.close();
+          require('child_process').spawn(exePath, ['--launcher'], { detached: true, stdio: 'ignore' }).unref();
+        });
+        probe.listen(7301, '0.0.0.0');
       }
       return { ok: true };
     } catch (err) {

--- a/main.js
+++ b/main.js
@@ -2108,6 +2108,48 @@ function connectWsjtx() {
         txFrequency: qso.txFrequency,
       });
     }
+    // Match callsign to a spotted POTA/SOTA activator and mark park as worked
+    const call = (qso.dxCall || '').toUpperCase();
+    if (call) {
+      const spot = lastPotaSotaSpots.find(s => s.callsign.toUpperCase() === call);
+      const freqHz = qso.txFrequency || 0;
+      const freqKhz = freqHz > 100000 ? freqHz / 1000 : freqHz; // WSJT-X sends Hz
+      const band = freqKhz ? (freqToBand(freqKhz / 1000) || '') : '';
+      const mode = (qso.mode || '').toUpperCase();
+      const now = new Date();
+      const qsoDate = now.getUTCFullYear().toString() +
+        String(now.getUTCMonth() + 1).padStart(2, '0') +
+        String(now.getUTCDate()).padStart(2, '0');
+      // Update workedQsos (callsign tracking)
+      const entry = { date: qsoDate, ref: spot ? (spot.reference || '').toUpperCase() : '', band, mode };
+      if (!workedQsos.has(call)) workedQsos.set(call, []);
+      workedQsos.get(call).push(entry);
+      if (win && !win.isDestroyed()) win.webContents.send('worked-qsos', [...workedQsos.entries()]);
+      if (remoteServer && remoteServer.running) remoteServer.sendWorkedQsos([...workedQsos.entries()]);
+      // Update roster needed sets
+      rosterWorkedCalls.add(call);
+      const grid = (qso.dxGrid || '').toUpperCase().substring(0, 4);
+      if (grid && /^[A-R]{2}\d{2}$/.test(grid)) rosterWorkedGrids.add(grid);
+      if (band && ctyDb) {
+        const entity = resolveCallsign(call, ctyDb);
+        if (entity) rosterWorkedDxcc.add(entity.name + '|' + band);
+      }
+      // Update workedParks if activator was at a park
+      if (spot && spot.reference) {
+        const parkRef = spot.reference.toUpperCase();
+        if (!workedParks.has(parkRef)) {
+          workedParks.set(parkRef, { reference: parkRef });
+          saveLocalWorkedPark(parkRef);
+          if (win && !win.isDestroyed()) win.webContents.send('worked-parks', [...workedParks.entries()]);
+          if (remoteServer && remoteServer.running) remoteServer.sendWorkedParks([...workedParks.keys()]);
+          sendCatLog(`[WSJT-X] QSO logged: ${call} → park ${parkRef} marked as worked`);
+        } else {
+          sendCatLog(`[WSJT-X] QSO logged: ${call} at ${parkRef} (already worked)`);
+        }
+      } else {
+        sendCatLog(`[WSJT-X] QSO logged: ${call} (no park match in spots)`);
+      }
+    }
   });
 
   const port = parseInt(settings.wsjtxPort, 10) || 2237;
@@ -2241,6 +2283,17 @@ async function jtcatAutoLog(qso) {
     sendCatLog(`[JTCAT] Auto-log skipped — no QSO data`);
     return;
   }
+  // Prevent logging incomplete QSOs (no signal reports exchanged)
+  if (!q.report && !q.sentReport) {
+    sendCatLog(`[JTCAT] Auto-log skipped — no signal reports exchanged for ${q.call}`);
+    return;
+  }
+  // Prevent double-logging the same QSO
+  if (q._logged) {
+    sendCatLog(`[JTCAT] Auto-log skipped — already logged ${q.call}`);
+    return;
+  }
+  q._logged = true;
   // When WSJT-X mode is enabled, WSJT-X handles logging via logged-adif (type 12).
   // Don't double-log from JTCAT's QSO state machine.
   if (settings.enableWsjtx && wsjtx && wsjtx.connected) {
@@ -2262,8 +2315,8 @@ async function jtcatAutoLog(qso) {
     band,
     qsoDate,
     timeOn: qsoTime,
-    rstSent: q.sentReport || '-00',
-    rstRcvd: q.report || '-00',
+    rstSent: q.sentReport || '',
+    rstRcvd: q.report || '',
     gridsquare: q.grid || '',
     comment: 'JTCAT ' + mode,
   };
@@ -2345,7 +2398,7 @@ function advanceJtcatQso(q, results, setTxMsg, onDone) {
     } else if (q.phase === 'cq-report') {
       const resp = results.find(d => { const t = (d.text || '').toUpperCase(); return t.indexOf(myCall) >= 0 && t.indexOf(q.call) >= 0; });
       if (!resp) { return; }
-      const rptM = (resp.text || '').toUpperCase().match(/R([+-]\d{2})/);
+      const rptM = (resp.text || '').toUpperCase().match(/R?([+-]\d{2})/);
       if (!rptM) {
         q._heardThisCycle = true; // they responded but haven't sent R+report yet
         return;
@@ -2416,7 +2469,7 @@ function advanceJtcatQso(q, results, setTxMsg, onDone) {
         setTxMsg(q.txMsg);
       }
     } else if (q.phase === 'r+report') {
-      if (text.indexOf('RR73') >= 0 || text.indexOf('RRR') >= 0 || text.indexOf(' 73') >= 0) {
+      if (/\bRR73\b/.test(text) || /\bRRR\b/.test(text) || /\s73$/.test(text)) {
         // They confirmed — QSO complete. Send 73 as courtesy, log now.
         q.txMsg = theirCall + ' ' + myCall + ' 73'; q.phase = '73';
         setTxMsg(q.txMsg);
@@ -2432,20 +2485,20 @@ function advanceJtcatQso(q, results, setTxMsg, onDone) {
 // Server-side QSO state machine wrappers
 function processRemoteJtcatQso(results) {
   const qso = remoteJtcatQso; // capture reference — don't rely on global in callbacks
-  advanceJtcatQso(qso, results, remoteJtcatSetTxMsg, () => {
-    jtcatAutoLog(qso); // use captured ref, not global
+  advanceJtcatQso(qso, results, remoteJtcatSetTxMsg, async () => {
+    await jtcatAutoLog(qso); // use captured ref, not global
     remoteJtcatBroadcastQso();
   });
 }
 
 function processPopoutJtcatQso(results) {
   const qso = popoutJtcatQso; // capture reference — don't rely on global in callbacks
-  advanceJtcatQso(qso, results, (msg) => {
+  advanceJtcatQso(qso, results, async (msg) => {
     const txEng = jtcatManager ? jtcatManager.txEngine : ft8Engine;
-    if (txEng) txEng.setTxMessage(msg);
+    if (txEng) await txEng.setTxMessage(msg);
     popoutBroadcastQso();
-  }, () => {
-    jtcatAutoLog(qso); // use captured ref, not global (global may be replaced by auto-CQ)
+  }, async () => {
+    await jtcatAutoLog(qso); // use captured ref, not global (global may be replaced by auto-CQ)
     popoutBroadcastQso();
   });
 }
@@ -2458,6 +2511,11 @@ function startJtcat(mode) {
   if (!jtcatManager) jtcatManager = new JtcatManager();
   jtcatManager.startSlice({ sliceId: 'default', mode: mode || 'FT8' });
   ft8Engine = jtcatManager.engine; // Phase 0 alias
+
+  // Remove any stale listeners from a previous startJtcat() cycle
+  ft8Engine.removeAllListeners('decode');
+  ft8Engine.removeAllListeners('tx-start');
+  ft8Engine.removeAllListeners('tx-end');
 
   ft8Engine.on('decode', async (data) => {
     // Enrich decodes with "needed" flags for call roster
@@ -2480,6 +2538,7 @@ function startJtcat(mode) {
         r.newCall = !rosterWorkedCalls.has(uc);
         r.watched = wlCalls.length > 0 && wlCalls.some(w => uc.indexOf(w) >= 0 || w.indexOf(uc) >= 0);
         // Extract grid from CQ messages (e.g. "CQ K1ABC FN42")
+        // Maidenhead grids: longitude field A-R, latitude field A-J, then 2 digits
         const gm = (r.text || '').match(/\b([A-R]{2}\d{2})\s*$/i);
         // Exclude FT8 exchanges that look like grids (RR73, RR99, etc.)
         if (gm && !(/^RR\d{2}$/i.test(gm[1]))) {
@@ -2713,6 +2772,19 @@ function startJtcat(mode) {
 }
 
 function stopJtcat() {
+  // Clean up any active QSOs to prevent stuck state
+  if (remoteJtcatQso) {
+    remoteJtcatQso = null;
+    if (remoteServer && remoteServer.hasClient && remoteServer.hasClient()) {
+      remoteServer.broadcastJtcatQsoState({ phase: 'idle' });
+    }
+  }
+  if (popoutJtcatQso) {
+    popoutJtcatQso = null;
+    if (jtcatPopoutWin && !jtcatPopoutWin.isDestroyed()) {
+      jtcatPopoutWin.webContents.send('jtcat-qso-state', { phase: 'idle' });
+    }
+  }
   if (jtcatManager) {
     jtcatManager.stopAll();
   }
@@ -4319,6 +4391,11 @@ function connectRemote() {
   // --- JTCAT remote control (event handlers — helpers are at file level) ---
 
   remoteServer.on('jtcat-start', ({ mode }) => {
+    // Close JTCAT popout if open — only one platform at a time
+    if (jtcatPopoutWin && !jtcatPopoutWin.isDestroyed()) {
+      sendCatLog('[JTCAT] Closing popout — ECHOCAT taking over FT8');
+      jtcatPopoutWin.close();
+    }
     startJtcat(mode);
     // Start audio capture in desktop renderer
     if (win && !win.isDestroyed()) win.webContents.send('jtcat-start-for-remote');
@@ -4362,8 +4439,8 @@ function connectRemote() {
     const nextSlot = ft8Engine._lastRxSlot === 'even' ? 'odd' : (ft8Engine._lastRxSlot === 'odd' ? 'even' : 'even');
     ft8Engine.setTxSlot(nextSlot);
     remoteJtcatQso = { mode: 'cq', call: null, grid: null, phase: 'cq', txMsg, report: null, sentReport: null, myCall, myGrid, txRetries: 0 };
+    await remoteJtcatSetTxMsg(txMsg); // encode first, then enable TX
     ft8Engine._txEnabled = true;
-    await remoteJtcatSetTxMsg(txMsg);
     ft8Engine.tryImmediateTx();
     console.log('[JTCAT Remote] CQ:', txMsg, '@ quiet freq', jtcatQuietFreq, 'Hz slot:', nextSlot);
   });
@@ -4381,7 +4458,7 @@ function connectRemote() {
         remoteJtcatQso.phase !== '73' && remoteJtcatQso.phase !== 'done' &&
         remoteJtcatQso.call.toUpperCase() !== (call || '').toUpperCase()) {
       sendCatLog(`[JTCAT] Replacing active QSO with ${remoteJtcatQso.call} — auto-logging`);
-      jtcatAutoLog(remoteJtcatQso);
+      await jtcatAutoLog(remoteJtcatQso);
     }
     // Halt any active TX (e.g. CQ) so reply goes out on next boundary
     if (targetEngine._txActive) targetEngine.txComplete();
@@ -4392,10 +4469,10 @@ function connectRemote() {
     const targetSlot = slot || targetEngine._lastRxSlot;
     targetEngine.setTxSlot(targetSlot === 'even' ? 'odd' : (targetSlot === 'odd' ? 'even' : 'auto'));
     remoteJtcatQso = { mode: 'reply', call, grid, phase: 'reply', txMsg, report: null, sentReport: null, myCall, myGrid, txRetries: 0, sliceId: sliceId || 'default' };
+    await remoteJtcatSetTxMsg(txMsg); // encode first, then enable TX
     targetEngine._txEnabled = true;
-    await remoteJtcatSetTxMsg(txMsg);
     targetEngine.tryImmediateTx();
-    console.log('[JTCAT Remote] Reply to', call, ':', txMsg, 'slot:', ft8Engine._txSlot);
+    console.log('[JTCAT Remote] Reply to', call, ':', txMsg, 'slot:', targetEngine._txSlot, 'locked:', targetEngine._lockedTxSlot);
   });
 
   remoteServer.on('jtcat-enable-tx', ({ enabled }) => {
@@ -4525,19 +4602,17 @@ function connectRemote() {
     remoteJtcatBroadcastQso();
   });
 
-  remoteServer.on('jtcat-skip-phase', () => {
+  remoteServer.on('jtcat-skip-phase', async () => {
     if (!remoteJtcatQso || remoteJtcatQso.phase === 'done' || remoteJtcatQso.phase === 'idle') return;
     const q = remoteJtcatQso;
     const myCall = q.myCall;
+    const validCall = q.call && /^[A-Z0-9/]{2,}$/i.test(q.call);
     if (q.mode === 'cq') {
-      if (q.phase === 'cq-report') {
-        q.txMsg = q.call + ' ' + myCall + ' RR73';
-        q.phase = 'cq-rr73';
-      } else if (q.phase === 'cq-rr73') {
+      if (q.phase === 'cq' || q.phase === 'cq-report') {
+        q.txMsg = validCall ? (q.call + ' ' + myCall + ' RR73') : '';
+        q.phase = validCall ? 'cq-rr73' : 'done';
+      } else {
         q.phase = 'done';
-        ft8Engine._txEnabled = false;
-        ft8Engine.setTxMessage('');
-        ft8Engine.setTxSlot('auto');
       }
     } else {
       if (q.phase === 'reply') {
@@ -4547,16 +4622,18 @@ function connectRemote() {
       } else if (q.phase === 'r+report') {
         q.txMsg = q.call + ' ' + myCall + ' RR73';
         q.phase = '73';
-      } else if (q.phase === '73') {
+      } else {
         q.phase = 'done';
-        ft8Engine._txEnabled = false;
-        ft8Engine.setTxMessage('');
-        ft8Engine.setTxSlot('auto');
       }
+    }
+    if (q.phase === 'done') {
+      ft8Engine._txEnabled = false;
+      ft8Engine.setTxMessage('');
+      ft8Engine.setTxSlot('auto');
     }
     q.txRetries = 0;
     if (q.txMsg && q.phase !== 'done') {
-      remoteJtcatSetTxMsg(q.txMsg);
+      await remoteJtcatSetTxMsg(q.txMsg);
     }
     remoteJtcatBroadcastQso();
     console.log('[JTCAT] Remote skip to phase:', q.phase, '— TX:', q.txMsg);
@@ -4699,7 +4776,10 @@ function handleRemotePtt(state) {
       // Suppress mode broadcasts for the entire PTT duration + restore.
       _modeSuppressUntil = Date.now() + 120000;
       // Change mode only — don't retune frequency (avoids 0Hz bug when freq unknown)
-      if (cat && cat.connected) cat.setModeOnly(dataMode);
+      if (cat && cat.connected) {
+        if (cat.setModeOnly) cat.setModeOnly(dataMode);
+        else if (_currentFreqHz) cat.tune(_currentFreqHz, dataMode);
+      }
     }
   }
 
@@ -4728,7 +4808,10 @@ function handleRemotePtt(state) {
     sendCatLog(`[PTT] Restoring ${restoreMode} mode`);
     // Suppress mode broadcasts during restore so ECHOCAT doesn't flicker
     _modeSuppressUntil = Date.now() + 2000;
-    if (cat && cat.connected) cat.setModeOnly(restoreMode);
+    if (cat && cat.connected) {
+      if (cat.setModeOnly) cat.setModeOnly(restoreMode);
+      else if (_currentFreqHz) cat.tune(_currentFreqHz, restoreMode);
+    }
   }
 
   _remoteTxState = state;
@@ -7378,25 +7461,6 @@ app.whenReady().then(() => {
           try { require('child_process').execSync(`launchctl load "${plistPath}"`, { stdio: 'pipe' }); } catch {}
           console.log('[Launcher] Installed to macOS LaunchAgents');
         }
-      } else {
-        // Linux: write autostart .desktop if not present, then spawn immediately if port is free
-        const autostartDir = path.join(require('os').homedir(), '.config', 'autostart');
-        const desktopPath = path.join(autostartDir, 'potacat-launcher.desktop');
-        if (!fs.existsSync(desktopPath)) {
-          fs.mkdirSync(autostartDir, { recursive: true });
-          fs.writeFileSync(desktopPath, `[Desktop Entry]\nType=Application\nName=POTACAT Launcher\nExec=${exePath} --launcher\nHidden=false\nNoDisplay=true\nX-GNOME-Autostart-enabled=true\n`);
-          console.log('[Launcher] Installed to Linux autostart');
-        }
-        // Start launcher only if port 7301 is not already in use
-        const net = require('net');
-        const probe = net.createServer();
-        probe.once('error', () => { /* port in use — launcher already running */ });
-        probe.once('listening', () => {
-          probe.close();
-          require('child_process').spawn(exePath, ['--launcher'], { detached: true, stdio: 'ignore' }).unref();
-          console.log('[Launcher] Started background process');
-        });
-        probe.listen(7301, '0.0.0.0');
       }
     } catch (err) {
       console.error('[Launcher] Setup failed:', err.message);
@@ -8086,6 +8150,21 @@ app.whenReady().then(() => {
       jtcatPopoutWin.focus();
       return;
     }
+    // Stop ECHOCAT JTCAT if running — only one platform at a time
+    if (remoteJtcatQso) {
+      remoteJtcatQso = null;
+      // Halt TX on the engine so it doesn't keep transmitting
+      if (ft8Engine) {
+        ft8Engine._txEnabled = false;
+        ft8Engine.setTxMessage('');
+        ft8Engine.setTxSlot('auto');
+      }
+      if (remoteServer && remoteServer.hasClient && remoteServer.hasClient()) {
+        remoteServer.broadcastJtcatQsoState({ phase: 'idle' });
+        remoteServer.broadcastJtcatStatus({ running: false });
+      }
+      sendCatLog('[JTCAT] Stopping ECHOCAT FT8 — popout taking over');
+    }
     const isMac = process.platform === 'darwin';
     jtcatPopoutWin = new BrowserWindow({
       width: 1100,
@@ -8118,6 +8197,15 @@ app.whenReady().then(() => {
     });
     jtcatPopoutWin.on('closed', () => {
       jtcatPopoutWin = null;
+      // Clear popout QSO state and halt TX so engine doesn't keep transmitting
+      if (popoutJtcatQso) {
+        popoutJtcatQso = null;
+        if (ft8Engine) {
+          ft8Engine._txEnabled = false;
+          ft8Engine.setTxMessage('');
+          ft8Engine.setTxSlot('auto');
+        }
+      }
       if (win && !win.isDestroyed()) {
         win.webContents.send('jtcat-popout-status', false);
       }
@@ -8184,7 +8272,7 @@ app.whenReady().then(() => {
         popoutJtcatQso.phase !== '73' && popoutJtcatQso.phase !== 'done' &&
         popoutJtcatQso.call.toUpperCase() !== (data.call || '').toUpperCase()) {
       sendCatLog(`[JTCAT] Replacing active QSO with ${popoutJtcatQso.call} — auto-logging`);
-      jtcatAutoLog(popoutJtcatQso);
+      await jtcatAutoLog(popoutJtcatQso);
     }
     // Halt any active TX (e.g. CQ) so reply goes out on next boundary
     if (replyEngine._txActive) replyEngine.txComplete();
@@ -8205,7 +8293,7 @@ app.whenReady().then(() => {
       const ourRpt = snr >= 0 ? '+' + String(Math.round(snr)).padStart(2, '0') : '-' + String(Math.abs(Math.round(snr))).padStart(2, '0');
       txMsg = data.call + ' ' + myCall + ' R' + ourRpt;
       phase = 'r+report';
-      popoutJtcatQso = { mode: 'reply', call: data.call, grid: data.grid, phase, txMsg, report: data.report, sentReport: ourRpt, myCall, myGrid, txRetries: 0 };
+      popoutJtcatQso = { mode: 'reply', call: data.call, grid: data.grid, phase, txMsg, report: data.report, sentReport: ourRpt, myCall, myGrid, txRetries: 0, sliceId: replySliceId };
     } else {
       // Fresh reply to CQ — start from beginning
       txMsg = data.call + ' ' + myCall + ' ' + myGrid;
@@ -8219,11 +8307,11 @@ app.whenReady().then(() => {
       popoutJtcatQso = { mode: 'reply', call: data.call, grid: data.grid || (sameCall ? prev.grid : ''), phase, txMsg,
         report: sameCall ? prev.report : null,
         sentReport: sameCall ? prev.sentReport : null,
-        myCall, myGrid, txRetries: 0 };
+        myCall, myGrid, txRetries: 0, sliceId: replySliceId };
       replyEngine._txEnabled = true;
       await replyEngine.setTxMessage(txMsg);
       replyEngine.tryImmediateTx();
-      if (!sameCall) jtcatAutoLog(popoutJtcatQso);
+      if (!sameCall) await jtcatAutoLog(popoutJtcatQso);
     } else if (!popoutJtcatQso || popoutJtcatQso.phase !== phase) {
       // Only set up QSO if not already created above (report case)
       if (phase === 'reply') {
@@ -8283,19 +8371,19 @@ app.whenReady().then(() => {
     console.log('[JTCAT Popout] Auto-CQ mode:', mode);
   });
 
-  ipcMain.on('jtcat-popout-skip-phase', () => {
+  ipcMain.on('jtcat-popout-skip-phase', async () => {
     if (!popoutJtcatQso || popoutJtcatQso.phase === 'done' || popoutJtcatQso.phase === 'idle') return;
     const q = popoutJtcatQso;
+    const eng = (q.sliceId && jtcatManager) ? jtcatManager.getEngine(q.sliceId) : ft8Engine;
+    if (!eng) return;
     const myCall = q.myCall;
+    const validCall = q.call && /^[A-Z0-9/]{2,}$/i.test(q.call);
     if (q.mode === 'cq') {
-      if (q.phase === 'cq-report') {
-        q.txMsg = q.call + ' ' + myCall + ' RR73';
-        q.phase = 'cq-rr73';
-      } else if (q.phase === 'cq-rr73') {
+      if (q.phase === 'cq' || q.phase === 'cq-report') {
+        q.txMsg = validCall ? (q.call + ' ' + myCall + ' RR73') : '';
+        q.phase = validCall ? 'cq-rr73' : 'done';
+      } else {
         q.phase = 'done';
-        ft8Engine._txEnabled = false;
-        ft8Engine.setTxMessage('');
-        ft8Engine.setTxSlot('auto');
       }
     } else {
       if (q.phase === 'reply') {
@@ -8305,28 +8393,32 @@ app.whenReady().then(() => {
       } else if (q.phase === 'r+report') {
         q.txMsg = q.call + ' ' + myCall + ' RR73';
         q.phase = '73';
-      } else if (q.phase === '73') {
+      } else {
         q.phase = 'done';
-        ft8Engine._txEnabled = false;
-        ft8Engine.setTxMessage('');
-        ft8Engine.setTxSlot('auto');
       }
+    }
+    if (q.phase === 'done') {
+      eng._txEnabled = false;
+      eng.setTxMessage('');
+      eng.setTxSlot('auto');
     }
     q.txRetries = 0;
     if (q.txMsg && q.phase !== 'done') {
-      if (ft8Engine) ft8Engine.setTxMessage(q.txMsg);
+      await eng.setTxMessage(q.txMsg);
     }
     popoutBroadcastQso();
     console.log('[JTCAT Popout] Skip to phase:', q.phase, '— TX:', q.txMsg);
   });
 
   ipcMain.on('jtcat-popout-cancel-qso', () => {
+    const q = popoutJtcatQso;
     popoutJtcatQso = null;
-    if (ft8Engine) {
-      ft8Engine._txEnabled = false;
-      ft8Engine.setTxMessage('');
-      ft8Engine.setTxSlot('auto');
-      if (ft8Engine._txActive) ft8Engine.txComplete();
+    const eng = (q && q.sliceId && jtcatManager) ? jtcatManager.getEngine(q.sliceId) : ft8Engine;
+    if (eng) {
+      eng._txEnabled = false;
+      eng.setTxMessage('');
+      eng.setTxSlot('auto');
+      if (eng._txActive) eng.txComplete();
     }
     popoutBroadcastQso();
     console.log('[JTCAT Popout] QSO cancelled');
@@ -8405,7 +8497,7 @@ app.whenReady().then(() => {
       'https://pota.app/', 'https://www.sotadata.org.uk/', 'https://wwff.co/', 'https://llota.app/',
       'https://tailscale.com', 'https://worldradioleague.com',
       'https://api.potacat.com/',
-      'http://rx.linkfanel.net/', 'http://kiwisdr.com/',
+      'http://rx.linkfanel.net', 'http://kiwisdr.com', 'http://websdr.org',
     ];
     if (allowed.some(prefix => url.startsWith(prefix))) {
       shell.openExternal(url);
@@ -8426,8 +8518,9 @@ app.whenReady().then(() => {
     }
   });
 
-  // --- KiwiSDR WebSDR integration ---
+  // --- KiwiSDR / WebSDR.org integration ---
   const { KiwiSdrClient } = require('./lib/kiwisdr');
+  const { WebSdrClient } = require('./lib/websdr');
   // kiwiClient and kiwiActive declared near top of whenReady for global access
 
   ipcMain.on('kiwi-connect', (_e, { host: rawHost, port: rawPort, password }) => {
@@ -8436,17 +8529,24 @@ app.whenReady().then(() => {
     const port = rawPort || 8073;
     if (!host) { sendCatLog('[WebSDR] No host specified'); return; }
     if (kiwiClient) kiwiClient.disconnect();
-    kiwiClient = new KiwiSdrClient();
+    // Auto-detect: port 8073 = KiwiSDR, other ports = WebSDR.org
+    const isWebSdr = port !== 8073;
+    if (isWebSdr) {
+      kiwiClient = new WebSdrClient();
+      sendCatLog(`[WebSDR] Using WebSDR.org protocol for ${host}:${port}`);
+    } else {
+      kiwiClient = new KiwiSdrClient();
+    }
     const kiwiFullHost = host + ':' + port;
     kiwiClient.on('connected', () => {
       kiwiActive = true;
       sendCatLog(`[WebSDR] Connected to ${kiwiFullHost}`);
-      // Auto-tune to current frequency
-      if (_currentFreqHz > 0 && _currentMode) {
+      // Auto-tune to current frequency (KiwiSDR needs tune after connect; WebSDR tunes at connect)
+      if (!isWebSdr && _currentFreqHz > 0 && _currentMode) {
         const mode = _currentMode.toLowerCase().replace('digu', 'usb').replace('digl', 'lsb').replace('pktusb', 'usb').replace('pktlsb', 'lsb');
         kiwiClient.tune(_currentFreqHz / 1000, mode);
       }
-      kiwiClient.setAgc(true);
+      if (kiwiClient.setAgc) kiwiClient.setAgc(true);
       for (const wc of require('electron').webContents.getAllWebContents()) {
         wc.send('kiwi-status', { connected: true, host: kiwiFullHost });
       }
@@ -8494,7 +8594,13 @@ app.whenReady().then(() => {
         remoteServer.sendToClient({ type: 'kiwi-status', connected: false, error: msg });
       }
     });
-    kiwiClient.connect(host, port, password);
+    if (isWebSdr) {
+      const freqKhz = _currentFreqHz > 0 ? _currentFreqHz / 1000 : 7200;
+      const mode = (_currentMode || 'USB').toLowerCase().replace('digu', 'usb').replace('digl', 'lsb').replace('pktusb', 'usb').replace('pktlsb', 'lsb');
+      kiwiClient.connect(host, port, freqKhz, mode);
+    } else {
+      kiwiClient.connect(host, port, password);
+    }
   });
 
   ipcMain.on('kiwi-disconnect', () => {
@@ -8833,15 +8939,6 @@ app.whenReady().then(() => {
         const autostartDir = path.join(os.homedir(), '.config', 'autostart');
         fs.mkdirSync(autostartDir, { recursive: true });
         fs.writeFileSync(path.join(autostartDir, 'potacat-launcher.desktop'), `[Desktop Entry]\nType=Application\nName=POTACAT Launcher\nExec=${exePath} --launcher\nHidden=false\nNoDisplay=true\nX-GNOME-Autostart-enabled=true\n`);
-        // Spawn immediately (same as Windows) — port probe prevents duplicate
-        const net = require('net');
-        const probe = net.createServer();
-        probe.once('error', () => { /* port in use — already running */ });
-        probe.once('listening', () => {
-          probe.close();
-          require('child_process').spawn(exePath, ['--launcher'], { detached: true, stdio: 'ignore' }).unref();
-        });
-        probe.listen(7301, '0.0.0.0');
       }
       return { ok: true };
     } catch (err) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "potacat",
-  "version": "1.3.14",
+  "version": "1.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "potacat",
-      "version": "1.3.14",
+      "version": "1.4.5",
       "dependencies": {
         "electron-updater": "^6.8.3",
         "ft8js": "^0.0.3",
@@ -433,6 +433,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -454,6 +455,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -470,6 +472,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -484,6 +487,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -1669,7 +1673,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2582,7 +2585,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2815,7 +2819,6 @@
       "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -3180,6 +3183,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -3200,6 +3204,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -4500,6 +4505,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -4851,7 +4857,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4881,6 +4886,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -4898,6 +4904,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -5105,6 +5112,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -5624,6 +5632,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "potacat",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "potacat",
-      "version": "1.4.5",
+      "version": "1.4.6",
       "dependencies": {
         "electron-updater": "^6.8.3",
         "ft8js": "^0.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "potacat",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "Amateur radio spot aggregator with CAT control, QSO logging, and panadapter integration",
   "author": {
     "name": "Casey Stanton",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "potacat",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "Amateur radio spot aggregator with CAT control, QSO logging, and panadapter integration",
   "author": {
     "name": "Casey Stanton",
@@ -55,6 +55,14 @@
       "!node_modules/electron/**/*",
       "!node_modules/electron-builder/**/*",
       "!node_modules/sharp/**/*"
+    ],
+    "asarUnpack": [
+      "lib/ft8-worker.js",
+      "lib/ft4/**/*",
+      "lib/ft2/**/*",
+      "lib/ft8_native/**/*",
+      "lib/freedv_native/**/*",
+      "lib/rade_native/**/*"
     ],
     "win": {
       "icon": "assets/icon.ico",

--- a/preload-vfo-popout.js
+++ b/preload-vfo-popout.js
@@ -24,6 +24,7 @@ contextBridge.exposeInMainWorld('api', {
   onSmeter: (cb) => ipcRenderer.on('cat-smeter', (_e, val) => cb(val)),
   onSwr: (cb) => ipcRenderer.on('cat-swr', (_e, val) => cb(val)),
   onSwrRatio: (cb) => ipcRenderer.on('cat-swr-ratio', (_e, val) => cb(val)),
+  onAlc: (cb) => ipcRenderer.on('cat-alc', (_e, val) => cb(val)),
   onTxState: (cb) => ipcRenderer.on('remote-tx-state', (_e, state) => cb(state)),
   onSolarData: (cb) => ipcRenderer.on('solar-data', (_e, data) => cb(data)),
   onTunedSpot: (cb) => ipcRenderer.on('vfo-tuned-spot', (_e, spot) => cb(spot)),

--- a/preload-vfo-popout.js
+++ b/preload-vfo-popout.js
@@ -24,7 +24,6 @@ contextBridge.exposeInMainWorld('api', {
   onSmeter: (cb) => ipcRenderer.on('cat-smeter', (_e, val) => cb(val)),
   onSwr: (cb) => ipcRenderer.on('cat-swr', (_e, val) => cb(val)),
   onSwrRatio: (cb) => ipcRenderer.on('cat-swr-ratio', (_e, val) => cb(val)),
-  onAlc: (cb) => ipcRenderer.on('cat-alc', (_e, val) => cb(val)),
   onTxState: (cb) => ipcRenderer.on('remote-tx-state', (_e, state) => cb(state)),
   onSolarData: (cb) => ipcRenderer.on('solar-data', (_e, data) => cb(data)),
   onTunedSpot: (cb) => ipcRenderer.on('vfo-tuned-spot', (_e, spot) => cb(spot)),

--- a/preload.js
+++ b/preload.js
@@ -25,6 +25,7 @@ contextBridge.exposeInMainWorld('api', {
   onCatSmeter: (cb) => ipcRenderer.on('cat-smeter', (_e, val) => cb(val)),
   onCatSwr: (cb) => ipcRenderer.on('cat-swr', (_e, val) => cb(val)),
   onCatSwrRatio: (cb) => ipcRenderer.on('cat-swr-ratio', (_e, val) => cb(val)),
+  onCatAlc: (cb) => ipcRenderer.on('cat-alc', (_e, val) => cb(val)),
   qrzLookup: (callsign) => ipcRenderer.invoke('qrz-lookup', callsign),
   qrzCheckSub: (force) => ipcRenderer.invoke('qrz-check-sub', force),
   qrzVerifyApiKey: (key) => ipcRenderer.invoke('qrz-verify-api-key', key),

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -9812,6 +9812,8 @@ const smeterBarCanvas = document.getElementById('smeter-bar');
 const smeterTextEl = document.getElementById('smeter-text');
 const swrBarCanvas = document.getElementById('swr-bar');
 const swrTextEl = document.getElementById('swr-text');
+const alcBarCanvas = document.getElementById('alc-bar');
+const alcTextEl = document.getElementById('alc-text');
 
 function drawMeterBar(canvas, level, color) {
   if (!canvas) return;
@@ -9867,6 +9869,15 @@ window.api.onCatSwrRatio((swr) => {
   drawMeterBar(swrBarCanvas, level, color);
   swrTextEl.textContent = swr < 10 ? swr.toFixed(1) : '>10';
   swrTextEl.style.color = color;
+});
+
+window.api.onCatAlc((val) => {
+  if (meterBoxVisible) meterBox.classList.remove('hidden');
+  const pct = Math.min(1, val / 100);
+  const color = pct <= 0 ? '#666' : pct < 0.4 ? '#4ecca3' : pct < 0.7 ? '#ffd740' : pct < 0.9 ? '#f0a500' : '#e94560';
+  drawMeterBar(alcBarCanvas, pct, pct <= 0 ? '#333' : color);
+  alcTextEl.textContent = Math.round(pct * 100) + '%';
+  alcTextEl.style.color = color;
 });
 
 window.api.onCatStatus((s) => {

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -16187,7 +16187,8 @@ window.api.onJtcatTxStatus(function(data) {
 window.api.onJtcatStartForRemote(function() {
   console.log('[JTCAT] Remote requested audio start');
   jtcatRemoteActive = true;
-  if (!jtcatAudioCtx) startJtcatAudio();
+  // Always restart audio — previous stream may be stale after phone disconnect/reconnect
+  startJtcatAudio();
 });
 window.api.onJtcatStopForRemote(function() {
   console.log('[JTCAT] Remote requested audio stop');

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -14938,6 +14938,7 @@ if (jtcatTxGainSlider) {
     var pct = parseInt(jtcatTxGainSlider.value, 10);
     jtcatTxGainVal.textContent = pct + '%';
     jtcatTxGainLevel = txPwrToGain(pct);
+    if (jtcatTxGainNode) jtcatTxGainNode.gain.value = jtcatTxGainLevel;
   });
 }
 // Accept RX gain from popout or ECHOCAT
@@ -14951,6 +14952,7 @@ window.api.onJtcatSetRxGain(function(level) {
 // Accept TX gain from popout or ECHOCAT
 window.api.onJtcatSetTxGain(function(level) {
   jtcatTxGainLevel = level;
+  if (jtcatTxGainNode) jtcatTxGainNode.gain.value = level;
   if (jtcatTxGainSlider) {
     jtcatTxGainSlider.value = gainToTxPwr(level);
     jtcatTxGainVal.textContent = gainToTxPwr(level) + '%';
@@ -16094,6 +16096,7 @@ window.api.onJtcatStatus(function(data) {
 // --- JTCAT TX Audio Playback ---
 var jtcatTxAudioCtx = null;
 var jtcatTxPlaying = false;
+var jtcatTxGainNode = null; // live GainNode during TX — updated by slider in real time
 
 async function playJtcatTxAudio(data) {
   var samplesArray = data.samples || data;
@@ -16128,16 +16131,17 @@ async function playJtcatTxAudio(data) {
     var source = jtcatTxAudioCtx.createBufferSource();
     source.buffer = buffer;
     // TX Power gain node — attenuates FT8 tone to prevent ALC overdrive
-    var txGain = jtcatTxAudioCtx.createGain();
-    txGain.gain.value = jtcatTxGainLevel;
-    source.connect(txGain);
-    txGain.connect(jtcatTxAudioCtx.destination);
+    jtcatTxGainNode = jtcatTxAudioCtx.createGain();
+    jtcatTxGainNode.gain.value = jtcatTxGainLevel;
+    source.connect(jtcatTxGainNode);
+    jtcatTxGainNode.connect(jtcatTxAudioCtx.destination);
 
     var txDone = false;
     function finishTx() {
       if (txDone) return;
       txDone = true;
       jtcatTxPlaying = false;
+      jtcatTxGainNode = null;
       window.api.jtcatTxComplete();
       console.log('[JTCAT] TX audio playback complete');
     }

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -1706,8 +1706,8 @@
     </fieldset>
     <!-- 8b. WebSDR (KiwiSDR) -->
     <fieldset class="source-toggles collapsible" data-settings-tab="station">
-      <legend>WebSDR (KiwiSDR)</legend>
-      <span class="help-text">Listen through a remote KiwiSDR receiver while transmitting on your local radio. Useful for local QRM.</span>
+      <legend>WebSDR</legend>
+      <span class="help-text">Listen through a remote receiver (KiwiSDR or WebSDR.org) while transmitting on your local radio. Useful for local QRM. Port 8073 = KiwiSDR, other ports = WebSDR.org.</span>
       <div style="display:flex;gap:6px;margin-top:8px;">
         <label style="flex:1;">Label: <input type="text" id="set-kiwi-label-1" placeholder="K3FEF" style="width:100%;max-width:80px;"></label>
         <label style="flex:3;">Host: <input type="text" id="set-kiwi-host-1" placeholder="host:port (e.g. k3fef.com:8073)" style="width:100%;max-width:260px;"></label>
@@ -1720,7 +1720,7 @@
         <label style="flex:1;">Label: <input type="text" id="set-kiwi-label-3" placeholder="VE3" style="width:100%;max-width:80px;"></label>
         <label style="flex:3;">Host: <input type="text" id="set-kiwi-host-3" placeholder="host:port (optional)" style="width:100%;max-width:260px;"></label>
       </div>
-      <span class="help-text" style="display:block;margin-top:4px;">Find public KiwiSDR stations at <a href="#" onclick="window.api.openExternal('http://rx.linkfanel.net');return false;" style="color:var(--accent-blue);">rx.linkfanel.net</a></span>
+      <span class="help-text" style="display:block;margin-top:4px;">Find stations: <a href="#" onclick="window.api.openExternal('http://rx.linkfanel.net');return false;" style="color:var(--accent-blue);">KiwiSDR</a> &middot; <a href="#" onclick="window.api.openExternal('http://websdr.org');return false;" style="color:var(--accent-blue);">WebSDR.org</a></span>
     </fieldset>
     <!-- 9. CW Keyer -->
     <fieldset class="source-toggles collapsible" data-settings-tab="station">

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -409,6 +409,11 @@
             <canvas id="swr-bar" width="120" height="14"></canvas>
             <span id="swr-text" class="meter-val">—</span>
           </div>
+          <div class="meter-row">
+            <span class="meter-label">ALC</span>
+            <canvas id="alc-bar" width="120" height="14"></canvas>
+            <span id="alc-text" class="meter-val">—</span>
+          </div>
         </div>
         <!-- Floating CW Macro box — draggable -->
         <div id="cw-macro-bar" class="cw-macro-box hidden">

--- a/renderer/jtcat-popout.html
+++ b/renderer/jtcat-popout.html
@@ -149,6 +149,7 @@
     <span id="jp-ptt-mode" style="font-size:10px;font-weight:600;padding:2px 6px;border-radius:3px;background:#333;color:#aaa;white-space:nowrap;" title="PTT method">PTT: CAT</span>
     <span id="jp-tx-freq-label" style="font-size:12px;font-weight:bold;color:#ff4444;white-space:nowrap;cursor:pointer;" title="Click to set TX frequency">TX: 1500 Hz</span>
     <div class="jtcat-status">
+      <span id="jp-utc-clock" style="font-size:11px;font-family:monospace;color:#4fc3f7;white-space:nowrap;" title="UTC date & time"></span>
       <span id="jp-cycle" class="jtcat-cycle">&mdash;</span>
       <span id="jp-countdown" class="jtcat-countdown">&mdash;</span>
       <span id="jp-sync" class="jtcat-sync">Sync: &mdash;</span>

--- a/renderer/jtcat-popout.js
+++ b/renderer/jtcat-popout.js
@@ -56,6 +56,17 @@
   var cycleEl = document.getElementById('jp-cycle');
   var countdownEl = document.getElementById('jp-countdown');
   var syncEl = document.getElementById('jp-sync');
+  var utcClockEl = document.getElementById('jp-utc-clock');
+
+  // UTC clock — updates every second
+  function updateUtcClock() {
+    var now = new Date();
+    var d = now.toISOString().slice(0, 10);
+    var t = now.toISOString().slice(11, 19);
+    utcClockEl.textContent = d + ' ' + t + 'Z';
+  }
+  updateUtcClock();
+  setInterval(updateUtcClock, 1000);
   var cqFilterBtn = document.getElementById('jp-cq-filter');
   var wantedFilterBtn = document.getElementById('jp-wanted-filter');
   var cqBtn = document.getElementById('jp-cq');

--- a/renderer/remote.html
+++ b/renderer/remote.html
@@ -204,7 +204,7 @@
         <button type="button" id="rc-audio-refresh" class="ft8-filter-btn" style="margin:4px 0 8px;">Refresh Devices</button>
 
         <!-- WebSDR -->
-        <div class="so-section-label">WebSDR (KiwiSDR)</div>
+        <div class="so-section-label">WebSDR</div>
         <div class="so-row">
           <label class="so-label">Enable</label>
           <div class="so-controls">
@@ -708,9 +708,6 @@
       <span class="em-label" style="margin-left:8px;">SWR:</span>
       <canvas id="echo-swr-bar" width="80" height="10" style="border-radius:2px;background:#111;"></canvas>
       <span id="echo-swr-text" class="em-val">—</span>
-      <span class="em-label" style="margin-left:8px;">ALC:</span>
-      <canvas id="echo-alc-bar" width="80" height="10" style="border-radius:2px;background:#111;"></canvas>
-      <span id="echo-alc-text" class="em-val">—</span>
     </div>
 
     <!-- Spot list -->

--- a/renderer/remote.html
+++ b/renderer/remote.html
@@ -708,6 +708,9 @@
       <span class="em-label" style="margin-left:8px;">SWR:</span>
       <canvas id="echo-swr-bar" width="80" height="10" style="border-radius:2px;background:#111;"></canvas>
       <span id="echo-swr-text" class="em-val">—</span>
+      <span class="em-label" style="margin-left:8px;">ALC:</span>
+      <canvas id="echo-alc-bar" width="80" height="10" style="border-radius:2px;background:#111;"></canvas>
+      <span id="echo-alc-text" class="em-val">—</span>
     </div>
 
     <!-- Spot list -->

--- a/renderer/remote.js
+++ b/renderer/remote.js
@@ -586,6 +586,14 @@
         startPing();
         showWelcome();
         drainOfflineQueue();
+        // Reset JTCAT state on reconnect — desktop may have stopped the engine while we were away
+        ft8Running = false;
+        // If already on FT8 tab, restart engine + tune to the active band
+        if (activeTab === 'ft8') {
+          ft8Send({ type: 'jtcat-start', mode: ft8Mode });
+          var selOpt = ft8BandSelect.options[ft8BandSelect.selectedIndex];
+          if (selOpt) ft8Send({ type: 'jtcat-set-band', band: selOpt.value, freqKhz: parseInt(selOpt.dataset.freq, 10) });
+        }
         if (activeTab === 'spots' || activeTab === 'map') {
           filterToolbar.classList.remove('hidden');
         }
@@ -4866,15 +4874,22 @@
         ft8Send({ type: 'jtcat-reply', call, grid, df: decode.df || 1500, sliceId: decode.sliceId });
       }
     } else if (myCallsign && text.indexOf(myCallsign.toUpperCase()) >= 0) {
-      // Directed at us — parse caller and reply (handles CQ→QSO transition on click)
+      // Directed at us — parse caller, detect report/RR73, pick up QSO mid-exchange
       const parts = text.split(/\s+/);
       const mc = myCallsign.toUpperCase();
       // Format: MYCALL THEIRCALL PAYLOAD — caller is the part that isn't our callsign
-      const caller = parts.find(p => p !== mc && /^[A-Z0-9]{3,}/.test(p));
-      const gridOrReport = parts[2] || '';
-      const grid = /^[A-R]{2}[0-9]{2}$/i.test(gridOrReport) ? gridOrReport : '';
+      const caller = parts.find(p => p !== mc && /^[A-Z0-9/]{2,}/.test(p));
+      const payload = parts[2] || '';
+      const grid = /^[A-R]{2}[0-9]{2}$/i.test(payload) ? payload : '';
+      const rptMatch = payload.match(/^R?([+-]\d{2})$/);
+      const hasRR73 = payload === 'RR73' || payload === 'RRR' || payload === '73';
       if (caller) {
-        ft8Send({ type: 'jtcat-reply', call: caller, grid, df: decode.df || 1500, sliceId: decode.sliceId });
+        ft8Send({
+          type: 'jtcat-reply', call: caller, grid, df: decode.df || 1500, sliceId: decode.sliceId,
+          report: rptMatch ? rptMatch[1] : undefined,
+          rr73: hasRR73 || undefined,
+          snr: decode.db,
+        });
       }
     } else {
       // Click on a non-CQ, non-directed decode — set TX freq to their freq

--- a/renderer/remote.js
+++ b/renderer/remote.js
@@ -675,6 +675,10 @@
         updateEchoSwrRatio(msg.value);
         break;
 
+      case 'alc':
+        updateEchoAlc(msg.value);
+        break;
+
       case 'tgxl-status':
         echoTgxlSection.classList.remove('hidden');
         echoTgxlUpdateButtons(msg.antenna || 0, msg.labels);
@@ -2814,6 +2818,8 @@
   var echoSmeterText = document.getElementById('echo-smeter-text');
   var echoSwrBar = document.getElementById('echo-swr-bar');
   var echoSwrText = document.getElementById('echo-swr-text');
+  var echoAlcBar = document.getElementById('echo-alc-bar');
+  var echoAlcText = document.getElementById('echo-alc-text');
   var echoShowMeter = document.getElementById('echo-show-meter');
   var echoMeterEnabled = localStorage.getItem('echoMeterEnabled') === 'true';
 
@@ -2936,6 +2942,15 @@
     drawEchoBar(echoSwrBar, level, color);
     echoSwrText.textContent = swr < 10 ? swr.toFixed(1) : '>10';
     echoSwrText.style.color = color;
+  }
+
+  function updateEchoAlc(val) {
+    if (!echoMeterEnabled || val <= 0) return;
+    var pct = Math.min(1, val / 60);
+    var color = pct < 0.4 ? '#4ecca3' : pct < 0.7 ? '#ffd740' : pct < 0.9 ? '#f0a500' : '#e94560';
+    drawEchoBar(echoAlcBar, pct, color);
+    echoAlcText.textContent = Math.round(pct * 100) + '%';
+    echoAlcText.style.color = color;
   }
 
   // --- Audio Level Meters & Gain Controls ---

--- a/renderer/remote.js
+++ b/renderer/remote.js
@@ -675,6 +675,10 @@
         updateEchoSwrRatio(msg.value);
         break;
 
+      case 'alc':
+        updateEchoAlc(msg.value);
+        break;
+
       case 'tgxl-status':
         echoTgxlSection.classList.remove('hidden');
         echoTgxlUpdateButtons(msg.antenna || 0, msg.labels);
@@ -2814,6 +2818,8 @@
   var echoSmeterText = document.getElementById('echo-smeter-text');
   var echoSwrBar = document.getElementById('echo-swr-bar');
   var echoSwrText = document.getElementById('echo-swr-text');
+  var echoAlcBar = document.getElementById('echo-alc-bar');
+  var echoAlcText = document.getElementById('echo-alc-text');
   var echoShowMeter = document.getElementById('echo-show-meter');
   var echoMeterEnabled = localStorage.getItem('echoMeterEnabled') === 'true';
 
@@ -2936,6 +2942,15 @@
     drawEchoBar(echoSwrBar, level, color);
     echoSwrText.textContent = swr < 10 ? swr.toFixed(1) : '>10';
     echoSwrText.style.color = color;
+  }
+
+  function updateEchoAlc(val) {
+    if (!echoMeterEnabled) return;
+    var pct = Math.min(1, val / 100);
+    var color = pct <= 0 ? '#666' : pct < 0.4 ? '#4ecca3' : pct < 0.7 ? '#ffd740' : pct < 0.9 ? '#f0a500' : '#e94560';
+    drawEchoBar(echoAlcBar, pct, pct <= 0 ? '#333' : color);
+    echoAlcText.textContent = pct <= 0 ? '\u2014' : Math.round(pct * 100) + '%';
+    echoAlcText.style.color = color;
   }
 
   // --- Audio Level Meters & Gain Controls ---

--- a/renderer/remote.js
+++ b/renderer/remote.js
@@ -675,10 +675,6 @@
         updateEchoSwrRatio(msg.value);
         break;
 
-      case 'alc':
-        updateEchoAlc(msg.value);
-        break;
-
       case 'tgxl-status':
         echoTgxlSection.classList.remove('hidden');
         echoTgxlUpdateButtons(msg.antenna || 0, msg.labels);
@@ -2818,8 +2814,6 @@
   var echoSmeterText = document.getElementById('echo-smeter-text');
   var echoSwrBar = document.getElementById('echo-swr-bar');
   var echoSwrText = document.getElementById('echo-swr-text');
-  var echoAlcBar = document.getElementById('echo-alc-bar');
-  var echoAlcText = document.getElementById('echo-alc-text');
   var echoShowMeter = document.getElementById('echo-show-meter');
   var echoMeterEnabled = localStorage.getItem('echoMeterEnabled') === 'true';
 
@@ -2942,15 +2936,6 @@
     drawEchoBar(echoSwrBar, level, color);
     echoSwrText.textContent = swr < 10 ? swr.toFixed(1) : '>10';
     echoSwrText.style.color = color;
-  }
-
-  function updateEchoAlc(val) {
-    if (!echoMeterEnabled || val <= 0) return;
-    var pct = Math.min(1, val / 60);
-    var color = pct < 0.4 ? '#4ecca3' : pct < 0.7 ? '#ffd740' : pct < 0.9 ? '#f0a500' : '#e94560';
-    drawEchoBar(echoAlcBar, pct, color);
-    echoAlcText.textContent = Math.round(pct * 100) + '%';
-    echoAlcText.style.color = color;
   }
 
   // --- Audio Level Meters & Gain Controls ---

--- a/renderer/vfo-popout.html
+++ b/renderer/vfo-popout.html
@@ -1422,15 +1422,6 @@ window.api.onSwr((val) => {
   swrText.style.color = color;
 });
 
-window.api.onAlc((val) => {
-  const pct = Math.min(100, (val / 100) * 100);
-  const color = pct <= 0 ? '#666' : pct < 40 ? '#4ecca3' : pct < 70 ? '#ffd740' : pct < 90 ? '#f0a500' : '#e94560';
-  alcBar.style.width = pct + '%';
-  alcBar.style.background = pct <= 0 ? '#333' : color;
-  alcText.textContent = pct <= 0 ? '\u2014' : Math.round(pct) + '%';
-  alcText.style.color = color;
-});
-
 window.api.onSwrRatio((swr) => {
   const pct = Math.min(100, ((swr - 1) / 4) * 100);
   const color = swr <= 1.5 ? '#4ecca3' : swr <= 2.0 ? '#ffd740' : swr <= 3.0 ? '#f0a500' : '#e94560';
@@ -1438,6 +1429,15 @@ window.api.onSwrRatio((swr) => {
   swrBar.style.background = color;
   swrText.textContent = swr < 10 ? swr.toFixed(1) : '>10';
   swrText.style.color = color;
+});
+
+window.api.onAlc((val) => {
+  const pct = Math.min(100, (val / 100) * 100);
+  const color = pct <= 0 ? '#666' : pct < 40 ? '#4ecca3' : pct < 70 ? '#ffd740' : pct < 90 ? '#f0a500' : '#e94560';
+  alcBar.style.width = pct + '%';
+  alcBar.style.background = pct <= 0 ? '#333' : color;
+  alcText.textContent = pct <= 0 ? '\u2014' : Math.round(pct) + '%';
+  alcText.style.color = color;
 });
 
 // --- PTT ---

--- a/renderer/vfo-popout.html
+++ b/renderer/vfo-popout.html
@@ -396,6 +396,11 @@
         <div class="meter-bar-wrap"><div class="meter-bar" id="swr-bar"></div></div>
         <span class="meter-text" id="swr-text">&mdash;</span>
       </div>
+      <div class="meter-row">
+        <span class="meter-label">ALC</span>
+        <div class="meter-bar-wrap"><div class="meter-bar" id="alc-bar"></div></div>
+        <span class="meter-text" id="alc-text">&mdash;</span>
+      </div>
     </div>
     <div class="widget-section" id="widget-ptt-row">
       <div class="ptt-log-row">
@@ -1385,6 +1390,8 @@ const smeterBar = document.getElementById('smeter-bar');
 const smeterText = document.getElementById('smeter-text');
 const swrBar = document.getElementById('swr-bar');
 const swrText = document.getElementById('swr-text');
+const alcBar = document.getElementById('alc-bar');
+const alcText = document.getElementById('alc-text');
 
 window.api.onSmeter((val) => {
   const pct = Math.min(100, (val / 255) * 100);
@@ -1413,6 +1420,15 @@ window.api.onSwr((val) => {
   swrBar.style.background = color;
   swrText.textContent = swr < 10 ? swr.toFixed(1) : '>10';
   swrText.style.color = color;
+});
+
+window.api.onAlc((val) => {
+  const pct = Math.min(100, (val / 100) * 100);
+  const color = pct <= 0 ? '#666' : pct < 40 ? '#4ecca3' : pct < 70 ? '#ffd740' : pct < 90 ? '#f0a500' : '#e94560';
+  alcBar.style.width = pct + '%';
+  alcBar.style.background = pct <= 0 ? '#333' : color;
+  alcText.textContent = pct <= 0 ? '\u2014' : Math.round(pct) + '%';
+  alcText.style.color = color;
 });
 
 window.api.onSwrRatio((swr) => {

--- a/renderer/vfo-popout.html
+++ b/renderer/vfo-popout.html
@@ -294,7 +294,7 @@
       flex: 1; padding: 10px;
       font-size: 14px; font-weight: bold; border: 2px solid var(--accent-gold);
       background: var(--bg-btn); color: var(--accent-gold); border-radius: 6px; cursor: pointer;
-      text-align: center; user-select: none; display: none;
+      text-align: center; user-select: none;
     }
     .sdr-btn-vfo:hover { background: var(--bg-btn-hover); }
     .sdr-btn-vfo.active { background: var(--accent-gold); color: #1a1a2e; }
@@ -395,11 +395,6 @@
         <span class="meter-label">SWR</span>
         <div class="meter-bar-wrap"><div class="meter-bar" id="swr-bar"></div></div>
         <span class="meter-text" id="swr-text">&mdash;</span>
-      </div>
-      <div class="meter-row">
-        <span class="meter-label">ALC</span>
-        <div class="meter-bar-wrap"><div class="meter-bar" id="alc-bar"></div></div>
-        <span class="meter-text" id="alc-text">&mdash;</span>
       </div>
     </div>
     <div class="widget-section" id="widget-ptt-row">
@@ -548,7 +543,7 @@
       <label class="settings-toggle"><input type="checkbox" id="w-cw"> CW Macros</label>
       <label class="settings-toggle"><input type="checkbox" id="w-cw-controls"> CW Speed / Text Input</label>
       <label class="settings-toggle"><input type="checkbox" id="w-voice"> Voice Macros</label>
-      <div class="section-label">WebSDR (KiwiSDR)</div>
+      <div class="section-label">WebSDR</div>
       <label class="settings-toggle"><input type="checkbox" id="w-kiwi"> Enable WebSDR RX</label>
       <div id="kiwi-config" style="padding-left:24px;display:none;">
         <select id="kiwi-station-select" style="width:100%;background:var(--bg-input);border:1px solid var(--border);color:var(--text-primary);padding:4px 8px;border-radius:4px;font-size:12px;margin:4px 0;">
@@ -1390,8 +1385,6 @@ const smeterBar = document.getElementById('smeter-bar');
 const smeterText = document.getElementById('smeter-text');
 const swrBar = document.getElementById('swr-bar');
 const swrText = document.getElementById('swr-text');
-const alcBar = document.getElementById('alc-bar');
-const alcText = document.getElementById('alc-text');
 
 window.api.onSmeter((val) => {
   const pct = Math.min(100, (val / 255) * 100);
@@ -1429,21 +1422,6 @@ window.api.onSwrRatio((swr) => {
   swrBar.style.background = color;
   swrText.textContent = swr < 10 ? swr.toFixed(1) : '>10';
   swrText.style.color = color;
-});
-
-window.api.onAlc((val) => {
-  if (val <= 0) {
-    alcBar.style.width = '0%';
-    alcText.textContent = '\u2014';
-    alcText.style.color = '#666';
-    return;
-  }
-  const pct = Math.min(100, (val / 60) * 100);
-  const color = pct < 40 ? '#4ecca3' : pct < 70 ? '#ffd740' : pct < 90 ? '#f0a500' : '#e94560';
-  alcBar.style.width = pct + '%';
-  alcBar.style.background = color;
-  alcText.textContent = Math.round(pct) + '%';
-  alcText.style.color = color;
 });
 
 // --- PTT ---
@@ -1815,7 +1793,7 @@ window.api.onTunedSpot((spot) => {
   updateCwSyncBtn();
 });
 
-// --- WebSDR (KiwiSDR) ---
+// --- WebSDR ---
 const kiwiBtnRow = document.getElementById('kiwi-btn-row');
 const wKiwiCb = document.getElementById('w-kiwi');
 const kiwiConfig = document.getElementById('kiwi-config');

--- a/renderer/vfo-popout.html
+++ b/renderer/vfo-popout.html
@@ -396,6 +396,11 @@
         <div class="meter-bar-wrap"><div class="meter-bar" id="swr-bar"></div></div>
         <span class="meter-text" id="swr-text">&mdash;</span>
       </div>
+      <div class="meter-row">
+        <span class="meter-label">ALC</span>
+        <div class="meter-bar-wrap"><div class="meter-bar" id="alc-bar"></div></div>
+        <span class="meter-text" id="alc-text">&mdash;</span>
+      </div>
     </div>
     <div class="widget-section" id="widget-ptt-row">
       <div class="ptt-log-row">
@@ -1385,6 +1390,8 @@ const smeterBar = document.getElementById('smeter-bar');
 const smeterText = document.getElementById('smeter-text');
 const swrBar = document.getElementById('swr-bar');
 const swrText = document.getElementById('swr-text');
+const alcBar = document.getElementById('alc-bar');
+const alcText = document.getElementById('alc-text');
 
 window.api.onSmeter((val) => {
   const pct = Math.min(100, (val / 255) * 100);
@@ -1422,6 +1429,21 @@ window.api.onSwrRatio((swr) => {
   swrBar.style.background = color;
   swrText.textContent = swr < 10 ? swr.toFixed(1) : '>10';
   swrText.style.color = color;
+});
+
+window.api.onAlc((val) => {
+  if (val <= 0) {
+    alcBar.style.width = '0%';
+    alcText.textContent = '\u2014';
+    alcText.style.color = '#666';
+    return;
+  }
+  const pct = Math.min(100, (val / 60) * 100);
+  const color = pct < 40 ? '#4ecca3' : pct < 70 ? '#ffd740' : pct < 90 ? '#f0a500' : '#e94560';
+  alcBar.style.width = pct + '%';
+  alcBar.style.background = color;
+  alcText.textContent = Math.round(pct) + '%';
+  alcText.style.color = color;
 });
 
 // --- PTT ---


### PR DESCRIPTION
## Summary

- **New ALC meter** — adds an ALC bar to the main window, VFO popout, and remote (ECHOCAT) web UI, displayed alongside the existing SWR and S-meters
- **Fix Yaesu RM meter channels** — Yaesu radios use different RM command numbers than Kenwood (Yaesu: RM2=ALC, RM4=SWR; Kenwood: RM3=ALC, RM1=SWR). `kenwood-codec` now selects the correct channels at construction time based on `model.brand`
- **Fix missing `alc` event relay** — `rig-controller` was emitting `swr` but not `alc` from the codec, so ALC values never reached the renderer
- **Fix meter polling during TX** — SWR and ALC are now polled only while transmitting (when they are meaningful); S-meter is polled only while receiving
- **Fix Linux remote launcher** — added Linux branch for boot-time auto-start and `install-launcher` IPC so the launcher persists across reboots on Linux

## Test plan

- [x] Tested on Yaesu FT-991A connected via serial CAT (KO4WIL)
- [x] ALC meter updates during voice TX in SSB mode
- [x] SWR meter updates during TX
- [x] S-meter updates during RX, clears during TX
- [x] ALC and SWR visible in main window, VFO popout, and ECHOCAT remote UI
- [x] Linux launcher persists across reboot

🤖 Generated with [Claude Code](https://claude.com/claude-code)