### PR TITLE
Change WWBOTA fetch spots to use server-sent events

### DIFF
--- a/lib/wwbota.js
+++ b/lib/wwbota.js
@@ -4,34 +4,47 @@
 //
 // Per the live OpenAPI at https://api.wwbota.net/openapi.json, both
 // GET and POST /spots/ are unauthenticated — no token required.
-const https = require('https');
+// Spots endpoint also supports Server-Sent Events, which allows spots
+// to be sent to clients as soon as they arrive therefore avoid polling
+const eventsource = require('eventsource')
 
 const HOST = 'api.wwbota.net';
 // 3-hour window — WWBOTA traffic is low-volume (mostly UK/EU bunker
 // activations), so a 1-hour window often returned empty when checked
 // from US time zones (Casey 2026-06-07). API clamps N to [0, 24].
 const SPOT_AGE_HOURS = 3;
+const SPOT_AGE_MS = SPOT_AGE_HOURS * 60 * 60 * 1000;
 
-function fetchSpots() {
-  return new Promise((resolve, reject) => {
-    https.get({
-      host: HOST,
-      path: `/spots/?age=${SPOT_AGE_HOURS}`,
-      headers: { 'User-Agent': 'POTACAT/1.0', 'Accept': 'application/json' },
-      timeout: 10000,
-    }, (res) => {
-      let data = '';
-      res.on('data', (chunk) => { data += chunk; });
-      res.on('end', () => {
-        try {
-          const parsed = JSON.parse(data);
-          resolve(Array.isArray(parsed) ? parsed : []);
-        } catch (e) {
-          reject(new Error('Failed to parse WWBOTA response'));
+let wwbotaEventSource;
+const wwbotaSpotsMap = new Map();
+
+async function fetchSpots() {
+  if (!wwbotaEventSource || wwbotaEventSource.readyState === eventsource.EventSource.CLOSED) {
+    // No current / active SSE connection
+    wwbotaEventSource = new eventsource.EventSource(`https://${HOST}/spots/?age=${SPOT_AGE_HOURS}`);
+    wwbotaEventSource.addEventListener('message', (ev) => {
+      try {
+        const spot = JSON.parse(ev.data);
+        if (spot && spot.call) {
+          wwbotaSpotsMap.set(spot.call, spot);
         }
-      });
-    }).on('error', reject);
-  });
+      } catch (e) {
+        console.error('Failed to parse WWBOTA response');
+      }
+    })
+  }
+
+  const now = Date.now();
+  for (const [call, spot] of wwbotaSpotsMap.entries()) {
+    if (spot.isoTime) {
+      const sDate = new Date(spot.isoTime);
+      if (now - sDate.getTime() > SPOT_AGE_MS) {
+        wwbotaSpotsMap.delete(call);
+      }
+    }
+  }
+
+  return Array.from(wwbotaSpotsMap.values())
 }
 
 // POST /spots/ takes { spotter, call, freq (MHz), mode, comment } where

--- a/lib/wwbota.js
+++ b/lib/wwbota.js
@@ -32,6 +32,8 @@ async function fetchSpots() {
         console.error('Failed to parse WWBOTA response');
       }
     })
+    // Wait briefly to allow messages to arrive from initial connection
+    await new Promise((r) => {setTimeout(r, 1000)})
   }
 
   const now = Date.now();

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@discordjs/opus": "^0.10.0",
         "bonjour-service": "^1.3.0",
         "electron-updater": "^6.8.3",
+        "eventsource": "^4.1.0",
         "ft8js": "^0.0.3",
         "leaflet": "^1.9.4",
         "qrcode": "^1.5.4",
@@ -3626,6 +3627,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-4.1.0.tgz",
+      "integrity": "sha512-2GuF51iuHX6A9xdTccMTsNb7VO0lHZihApxhvQzJB5A03DvHDd2FQepodbMaztPBmBcE/ox7o2gqaxGhYB9LhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/exponential-backoff": {

--- a/package.json
+++ b/package.json
@@ -177,6 +177,7 @@
     "@discordjs/opus": "^0.10.0",
     "bonjour-service": "^1.3.0",
     "electron-updater": "^6.8.3",
+    "eventsource": "^4.1.0",
     "ft8js": "^0.0.3",
     "leaflet": "^1.9.4",
     "qrcode": "^1.5.4",


### PR DESCRIPTION
Great to see WWBOTA as part of POTACAT :smile_cat: 

WWBOTA supports Server-Sent Events (SSE) as a more efficient to send spots from server to client, which reduces bandwidth and load.

This PR changes the fetch spots for WWBOTA to spawn an SSE connection (on first call) to maintain a set of spots, which are returned with the fetchSpots() call.