### PR TITLE
feat(rsba1): main.js integration — connection, RX audio pacer, TX dispatch

### DIFF
--- a/lib/rsba1-transport.js
+++ b/lib/rsba1-transport.js
@@ -14,7 +14,7 @@
 //
 // Protocol summary
 // ---------------------------------------------------------------------------
-// Icom's network protocol uses two parallel UDP socket pairs between
+// Icom's network protocol uses three parallel UDP socket pairs between
 // client and radio (or wfserver):
 //
 //   * control stream — port 50001 by default. Carries handshake, login,
@@ -26,8 +26,11 @@
 //     (datalen + sendseq fields). The bytes after the header are the
 //     same CI-V frames POTACAT's CivCodec already produces and parses.
 //
-// (Audio runs on a third socket pair, port 50003 by default; not in
-// this transport — Phase 2.)
+//   * audio stream — port 50003 by default. Same handshake pattern, then
+//     carries RX/TX audio in a 24-byte data-packet header plus codec payload.
+//     POTACAT uses LPCM16 mono for the first production TX path because it is
+//     the simplest wfview/RS-BA1 audio mode and works for generated FT8/SSTV
+//     tones without requiring an Opus/uLAW encoder.
 //
 // Per-stream handshake
 //   1. Client → AreYouThere (control packet, type 0x03), retried every
@@ -59,6 +62,8 @@
 // ===========================================================================
 
 const dgram = require('dgram');
+const dns = require('dns').promises;
+const os = require('os');
 const { EventEmitter } = require('events');
 
 // --- Packet sizes (from wfview's packettypes.h) ---
@@ -70,10 +75,30 @@ const STATUS_SIZE  = 0x50;
 const LOGIN_RESPONSE_SIZE = 0x60;
 const LOGIN_SIZE   = 0x80;
 const CONNINFO_SIZE = 0x90;
+const CAPABILITIES_SIZE = 0x42;
+const RADIO_CAP_SIZE = 0x66;
 const CIV_HEADER_SIZE = 0x15;
+const AUDIO_HEADER_SIZE = 0x18;
+const AUDIO_CODEC_LPCM16_MONO = 0x04;
+const AUDIO_CODEC_LPCM16_STEREO = 0x10;
+const AUDIO_TX_MAX_PAYLOAD = 1364; // wfview splits outbound audio at this size
+const ICOM_AUDIO_TX_SAMPLE_RATE = 48000;
+const DEFAULT_TX_AUDIO_BUFFER_MS = 250;
+const AUDIO_FRAME_PERIOD_MS = 20; // wfview AUDIO_PERIOD: one real-time audio block per 20ms
+const TX_BUFFER_SAFETY_MS = 50;
+const TX_MAX_PACE_LEAD_MS = 150;
+const MAX_TX_FRAMES_PER_PUMP = 3;
+const TX_SLOT_AUDIO_START_MS = 500; // WSJT-X FT8 convention; FT4 callers can override to 300ms.
+const TX_TAIL_SILENCE_MS = 0;
+// Voice TX streaming constants.
+// Frame samples = one 20 ms block at 48 kHz, same cadence as batch TX.
+const VOICE_TX_FRAME_SAMPLES = 960;  // 20 ms @ 48 kHz
+// Ring buffer holds 3 seconds of audio to absorb IPC/WebRTC jitter.
+const VOICE_TX_RING_SAMPLES = 48000 * 3;
 
 // --- Type codes (control packet `type` field at offset 0x04) ---
-const TYPE_RETRANSMIT = 0x00;
+const TYPE_IDLE       = 0x00;
+const TYPE_RETRANSMIT_REQUEST = 0x01;
 const TYPE_AYT        = 0x03;
 const TYPE_IAMHERE    = 0x04;
 const TYPE_DISCONNECT = 0x05;
@@ -86,6 +111,11 @@ const PING_PERIOD    = 500;
 const IDLE_PERIOD    = 100;
 const TOKEN_RENEWAL  = 60000;
 const HANDSHAKE_TIMEOUT = 10000; // give up if not authenticated after 10s
+const TX_BUFFER_LIMIT = 4096;
+const RX_RETRANSMIT_PERIOD = 100;
+const RX_RETRANSMIT_MAX_ATTEMPTS = 4;
+const RX_MISSING_LIMIT = 50;
+const TX_RETRANSMIT_DEDUPE_MS = 35;
 
 // --- passcode lookup table (256 bytes, indices 0-255) ---
 // Indices 0-31 and 127-255 are zero (unused). Indices 32-126 are the
@@ -121,6 +151,182 @@ function randomId() {
   return ((Math.floor(Math.random() * 0x7fffffff) | 0x10000000) >>> 0);
 }
 
+function streamIdFromLocalAddress(address, localPort) {
+  const parts = String(address || '').split('.').map((part) => Number(part));
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) {
+    return randomId();
+  }
+  const port = Number(localPort) & 0xffff;
+  return (((parts[2] & 0xff) << 24) | ((parts[3] & 0xff) << 16) | port) >>> 0;
+}
+
+function ipv4ToInt(address) {
+  const parts = String(address || '').split('.').map((part) => Number(part));
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) {
+    return null;
+  }
+  return (((parts[0] << 24) | (parts[1] << 16) | (parts[2] << 8) | parts[3]) >>> 0);
+}
+
+function popcount32(value) {
+  let n = value >>> 0;
+  let count = 0;
+  while (n) {
+    count += n & 1;
+    n >>>= 1;
+  }
+  return count;
+}
+
+function isTunnelInterface(name) {
+  return /^(utun|tun|tap|tailscale|wg|awdl|llw)/i.test(String(name || ''));
+}
+
+function isPreferredLanInterface(name) {
+  return /^(en|eth|wlan|wl|bridge)/i.test(String(name || ''));
+}
+
+function selectLocalAddressForTarget(remoteHost, routedAddress = null, interfaces = os.networkInterfaces()) {
+  const target = ipv4ToInt(remoteHost);
+  const routed = routedAddress ? String(routedAddress) : null;
+  if (target == null) return { address: routed, source: routed ? 'route' : 'none', routedAddress: routed };
+
+  const routedInt = ipv4ToInt(routed);
+  let routedMatches = false;
+  const candidates = [];
+  for (const [name, addrs] of Object.entries(interfaces || {})) {
+    for (const addr of addrs || []) {
+      const family = addr && (addr.family === 4 || addr.family === 'IPv4');
+      if (!family || !addr.address) continue;
+      const addrInt = ipv4ToInt(addr.address);
+      const maskInt = ipv4ToInt(addr.netmask || '255.255.255.255');
+      if (addrInt == null || maskInt == null) continue;
+      if (((addrInt & maskInt) >>> 0) !== ((target & maskInt) >>> 0)) continue;
+      const prefix = popcount32(maskInt);
+      if (routedInt != null && addrInt === routedInt) routedMatches = true;
+      candidates.push({
+        name,
+        address: addr.address,
+        prefix,
+        internal: addr.internal === true,
+        tunnel: isTunnelInterface(name),
+        lan: isPreferredLanInterface(name),
+        routed: routedInt != null && addrInt === routedInt,
+      });
+    }
+  }
+
+  if (routed && routedMatches) {
+    return { address: routed, source: 'route', routedAddress: routed };
+  }
+  if (!candidates.length) {
+    return { address: routed, source: routed ? 'route' : 'none', routedAddress: routed };
+  }
+
+  candidates.sort((a, b) => {
+    const score = (c) =>
+      (c.lan ? 1000 : 0) +
+      (!c.tunnel ? 300 : -300) +
+      (!c.internal ? 100 : -100) +
+      (c.routed ? 50 : 0) +
+      c.prefix;
+    return score(b) - score(a);
+  });
+  const best = candidates[0];
+  return {
+    address: best.address,
+    source: routed && best.address !== routed ? 'same-subnet' : (best.routed ? 'route' : 'same-subnet'),
+    routedAddress: routed,
+    interfaceName: best.name,
+  };
+}
+
+function findLocalAddressForTarget(remoteHost, remotePort) {
+  return new Promise((resolve) => {
+    const sock = dgram.createSocket('udp4');
+    let settled = false;
+    const done = (address) => {
+      if (settled) return;
+      settled = true;
+      try { sock.close(); } catch { /* ignore */ }
+      const routed = address && address !== '0.0.0.0' ? address : null;
+      resolve(selectLocalAddressForTarget(remoteHost, routed));
+    };
+    const timer = setTimeout(() => done(null), 1000);
+    if (timer && typeof timer.unref === 'function') timer.unref();
+    sock.once('error', () => {
+      clearTimeout(timer);
+      done(null);
+    });
+    try {
+      sock.connect(Number(remotePort) || 9, remoteHost, () => {
+        clearTimeout(timer);
+        let address = null;
+        try {
+          const info = sock.address();
+          address = info && info.address;
+        } catch { /* ignore */ }
+        done(address);
+      });
+    } catch {
+      clearTimeout(timer);
+      done(null);
+    }
+  });
+}
+
+function makeRsba1Error(message, code, details = {}) {
+  const err = new Error(message);
+  err.code = code;
+  err.details = details;
+  return err;
+}
+
+function cString(buf, offset, len) {
+  const end = Math.min(buf.length, offset + len);
+  let stop = offset;
+  while (stop < end && buf[stop] !== 0) stop++;
+  return buf.slice(offset, stop).toString('ascii').trim();
+}
+
+function isCapabilitiesPacket(buf) {
+  if (!buf || buf.length < CAPABILITIES_SIZE) return false;
+  const len = buf.readUInt32LE(0);
+  if (len !== buf.length) return false;
+  return (buf.length - CAPABILITIES_SIZE) % RADIO_CAP_SIZE === 0;
+}
+
+function parseCapabilities(buf) {
+  if (!isCapabilitiesPacket(buf)) return [];
+  const declared = buf.readUInt16LE(0x40);
+  const available = Math.floor((buf.length - CAPABILITIES_SIZE) / RADIO_CAP_SIZE);
+  const count = Math.min(declared || available, available);
+  const radios = [];
+  for (let i = 0; i < count; i++) {
+    const base = CAPABILITIES_SIZE + i * RADIO_CAP_SIZE;
+    const commoncap = buf.readUInt16LE(base + 0x07);
+    const macAddress = Buffer.from(buf.slice(base + 0x0a, base + 0x10));
+    const guid = Buffer.from(buf.slice(base, base + 0x10));
+    const name = cString(buf, base + 0x10, 32);
+    const audio = cString(buf, base + 0x30, 32);
+    radios.push({
+      commoncap,
+      macAddress,
+      guid,
+      useGuid: commoncap !== 0x8010,
+      name,
+      audio,
+      conntype: buf.readUInt16LE(base + 0x50),
+      civAddress: buf.readUInt8(base + 0x52),
+      rxSampleMask: buf.readUInt16LE(base + 0x53),
+      txSampleMask: buf.readUInt16LE(base + 0x55),
+      baudrate: buf.readUInt32BE(base + 0x5a),
+      capf: buf.readUInt16LE(base + 0x5e),
+    });
+  }
+  return radios;
+}
+
 // --- Header builders ---
 
 function buildControl(type, seq, sentid, rcvdid) {
@@ -130,6 +336,26 @@ function buildControl(type, seq, sentid, rcvdid) {
   buf.writeUInt16LE(seq,           6);
   buf.writeUInt32LE(sentid,        8);
   buf.writeUInt32LE(rcvdid,       12);
+  return buf;
+}
+
+function buildRetransmitRange(seq, sentid, rcvdid, missingSeqs) {
+  const seqs = Array.isArray(missingSeqs) ? missingSeqs : [];
+  const buf = Buffer.alloc(CONTROL_SIZE + seqs.length * 4, 0);
+  buf.writeUInt32LE(buf.length, 0);
+  buf.writeUInt16LE(TYPE_RETRANSMIT_REQUEST, 4);
+  buf.writeUInt16LE(seq & 0xffff, 6);
+  buf.writeUInt32LE(sentid >>> 0, 8);
+  buf.writeUInt32LE(rcvdid >>> 0, 12);
+  let off = CONTROL_SIZE;
+  for (const raw of seqs) {
+    const s = Number(raw) & 0xffff;
+    // wfview places each missing sequence twice in the variable-length
+    // retransmit request. Radios and wfserver accept the duplicate pair.
+    buf.writeUInt16LE(s, off);
+    buf.writeUInt16LE(s, off + 2);
+    off += 4;
+  }
   return buf;
 }
 
@@ -177,10 +403,17 @@ function buildToken(seq, sentid, rcvdid, innerSeq, tokRequest, token, magic) {
   buf.writeUInt16BE(innerSeq,    0x16);
   buf.writeUInt16LE(tokRequest,  0x1a);
   buf.writeUInt32LE(token >>> 0, 0x1c);
+  buf.writeUInt16BE(0x0798,      0x24); // resetcap; wfview sends this on token confirm/renewal
   return buf;
 }
 
-function buildConnInfo(seq, sentid, rcvdid, innerSeq, tokRequest, token, username, devName, civPort, audioPort) {
+function buildConnInfo(seq, sentid, rcvdid, innerSeq, tokRequest, token, username, devName, civPort, audioPort, audio = {}, radioInfo = null) {
+  const enableRxAudio = audio.enableRx === true;
+  const enableTxAudio = audio.enableTx === true;
+  const rxCodec = enableRxAudio ? (audio.rxCodec || AUDIO_CODEC_LPCM16_MONO) : 0x00;
+  const txCodec = enableTxAudio ? (audio.txCodec || AUDIO_CODEC_LPCM16_MONO) : 0x00;
+  const rxSampleRate = enableRxAudio ? (audio.rxSampleRate || 48000) : 0;
+  const txSampleRate = enableTxAudio ? (audio.txSampleRate || ICOM_AUDIO_TX_SAMPLE_RATE) : 0;
   const buf = Buffer.alloc(CONNINFO_SIZE, 0);
   buf.writeUInt32LE(CONNINFO_SIZE, 0x00);
   buf.writeUInt16LE(0,            0x04);
@@ -193,32 +426,39 @@ function buildConnInfo(seq, sentid, rcvdid, innerSeq, tokRequest, token, usernam
   buf.writeUInt16BE(innerSeq,     0x16);
   buf.writeUInt16LE(tokRequest,   0x1a);
   buf.writeUInt32LE(token >>> 0,  0x1c);
-  buf.writeUInt16LE(0x8010,       0x27); // commoncap
-  // macaddress is left zero — we're not pretending to be a specific NIC
-  Buffer.from(String(devName || 'POTACAT-Radio').slice(0, 32), 'ascii').copy(buf, 0x40);
+  if (radioInfo && radioInfo.useGuid && radioInfo.guid && radioInfo.guid.length >= 16) {
+    radioInfo.guid.copy(buf, 0x20, 0, 16);
+  } else {
+    buf.writeUInt16LE((radioInfo && radioInfo.commoncap) || 0x8010, 0x27);
+    if (radioInfo && radioInfo.macAddress && radioInfo.macAddress.length >= 6) {
+      radioInfo.macAddress.copy(buf, 0x2a, 0, 6);
+    }
+  }
+  Buffer.from(String((radioInfo && radioInfo.name) || devName || 'POTACAT-Radio').slice(0, 32), 'ascii').copy(buf, 0x40);
   passcodeBytes(username, 16).copy(buf, 0x60);
-  buf.writeUInt8(0x01,         0x70); // rxenable
-  buf.writeUInt8(0x00,         0x71); // txenable (Phase 1: no TX audio)
-  buf.writeUInt8(0x00,         0x72); // rxcodec  (Phase 1: no audio)
-  buf.writeUInt8(0x00,         0x73); // txcodec
-  buf.writeUInt32BE(0,         0x74); // rxsample
-  buf.writeUInt32BE(0,         0x78); // txsample
+  buf.writeUInt8(enableRxAudio ? 0x01 : 0x00, 0x70); // rxenable
+  buf.writeUInt8(enableTxAudio ? 0x01 : 0x00, 0x71); // txenable
+  buf.writeUInt8(rxCodec,      0x72); // rxcodec
+  buf.writeUInt8(txCodec,      0x73); // txcodec
+  buf.writeUInt32BE(rxSampleRate, 0x74); // rxsample
+  buf.writeUInt32BE(txSampleRate, 0x78); // txsample
   buf.writeUInt32BE(civPort,   0x7c);
   buf.writeUInt32BE(audioPort, 0x80);
-  buf.writeUInt32BE(50,        0x84); // txbuffer (latency hint)
+  buf.writeUInt32BE(audio.txBufferMs || DEFAULT_TX_AUDIO_BUFFER_MS, 0x84); // txbuffer (latency hint)
   buf.writeUInt8(0x01,         0x88); // convert
   return buf;
 }
 
-function buildOpenClose(seq, sentid, rcvdid, close, magic) {
+function buildOpenClose(seq, sentid, rcvdid, close, magic = 0x04, sendSeqB = 0) {
   const buf = Buffer.alloc(OPENCLOSE_SIZE, 0);
   buf.writeUInt32LE(OPENCLOSE_SIZE, 0x00);
   buf.writeUInt16LE(0,              0x04);
-  buf.writeUInt16LE(seq,            0x06);
+  buf.writeUInt16LE(seq & 0xffff,   0x06);
   buf.writeUInt32LE(sentid,         0x08);
   buf.writeUInt32LE(rcvdid,         0x0c);
-  buf.writeUInt16LE(close ? 0x0005 : 0x0001, 0x10); // 0x10: 0x0001 open / 0x0005 close
-  // 0x12 unused, 0x13 sendseq (we don't track), 0x15 magic byte
+  buf.writeUInt16LE(close ? 0x05c0 : 0x01c0, 0x10);
+  buf.writeUInt16BE(sendSeqB & 0xffff, 0x13);
+  // 0x14 unused, 0x15 magic byte
   buf.writeUInt8(magic | 0,         0x15);
   return buf;
 }
@@ -231,14 +471,169 @@ function buildCivData(seq, sentid, rcvdid, sendSeqB, civPayload) {
   const buf = Buffer.alloc(total, 0);
   buf.writeUInt32LE(total,       0x00);
   buf.writeUInt16LE(0,           0x04);
-  buf.writeUInt16LE(seq,         0x06);
+  buf.writeUInt16LE(seq & 0xffff, 0x06);
   buf.writeUInt32LE(sentid,      0x08);
   buf.writeUInt32LE(rcvdid,      0x0c);
   buf.writeUInt8(0xc1,           0x10);
   buf.writeUInt16LE(civPayload.length, 0x11);
-  buf.writeUInt16BE(sendSeqB,    0x13);
+  buf.writeUInt16BE(sendSeqB & 0xffff, 0x13);
   civPayload.copy(buf, CIV_HEADER_SIZE);
   return buf;
+}
+
+// Audio data wrapper for the audio stream.
+// wfview sends outbound audio with len/type/seq/sentid/rcvdid in native LE,
+// sendseq + datalen in BE, and an LE ident field (usually 0x0080).
+function buildAudioData(seq, sentid, rcvdid, sendSeqB, payload) {
+  const total = AUDIO_HEADER_SIZE + payload.length;
+  const buf = Buffer.alloc(total, 0);
+  buf.writeUInt32LE(total,       0x00);
+  buf.writeUInt16LE(0,           0x04);
+  buf.writeUInt16LE(seq & 0xffff, 0x06);
+  buf.writeUInt32LE(sentid,      0x08);
+  buf.writeUInt32LE(rcvdid,      0x0c);
+  buf.writeUInt16LE(payload.length === 0xa0 ? 0x9781 : 0x0080, 0x10);
+  buf.writeUInt16BE(sendSeqB & 0xffff, 0x12);
+  buf.writeUInt16BE(payload.length, 0x16);
+  payload.copy(buf, AUDIO_HEADER_SIZE);
+  return buf;
+}
+
+function decodeLpcm16Mono(payload) {
+  const frames = payload.length >> 1;
+  const pcm = new Float32Array(frames);
+  for (let i = 0; i < frames; i++) {
+    pcm[i] = payload.readInt16LE(i * 2) / 32768;
+  }
+  return pcm;
+}
+
+function coerceFloat32(input) {
+  if (input instanceof Float32Array) return input;
+  if (ArrayBuffer.isView(input)) {
+    return new Float32Array(input.buffer, input.byteOffset, Math.floor(input.byteLength / Float32Array.BYTES_PER_ELEMENT));
+  }
+  if (input instanceof ArrayBuffer) return new Float32Array(input);
+  if (Array.isArray(input)) return new Float32Array(input);
+  return new Float32Array(0);
+}
+
+function clampTailSilenceMs(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return TX_TAIL_SILENCE_MS;
+  return Math.max(0, Math.min(1000, n));
+}
+
+function clampStartDelayMs(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return TX_SLOT_AUDIO_START_MS;
+  return Math.max(0, Math.min(1500, n));
+}
+
+function resampleMonoFloat32(input, fromRate, toRate) {
+  const src = coerceFloat32(input);
+  if (!src.length) return src;
+  const from = Number(fromRate) || toRate;
+  const to = Number(toRate) || from;
+  if (!from || !to || from === to) return src;
+
+  // TX audio is usually JTCAT's 12 kHz FT8/FT4 waveform expanded to the
+  // radio's 48 kHz RS-BA1 stream. Linear interpolation leaves audible/image
+  // energy around narrow digital tones; wfview uses a real converter path, so
+  // use a compact windowed-sinc reconstruction here for the direct-radio path.
+  return resampleMonoFloat32Sinc(src, from, to);
+}
+
+function sinc(x) {
+  if (Math.abs(x) < 1e-8) return 1;
+  const pix = Math.PI * x;
+  return Math.sin(pix) / pix;
+}
+
+function blackmanWindow(index, length) {
+  if (length <= 1) return 1;
+  const x = 2 * Math.PI * index / (length - 1);
+  return 0.42 - 0.5 * Math.cos(x) + 0.08 * Math.cos(2 * x);
+}
+
+function resampleMonoFloat32Sinc(src, fromRate, toRate) {
+  const from = Number(fromRate) || toRate;
+  const to = Number(toRate) || from;
+  const outLen = Math.max(1, Math.round(src.length * to / from));
+  const out = new Float32Array(outLen);
+  const ratio = from / to;
+  const cutoff = Math.min(1, to / from);
+  const radius = 16;
+  const taps = radius * 2;
+  for (let i = 0; i < outLen; i++) {
+    const pos = i * ratio;
+    const center = Math.floor(pos);
+    let sum = 0;
+    let weightSum = 0;
+    for (let tap = -radius + 1; tap <= radius; tap++) {
+      const idx = center + tap;
+      if (idx < 0 || idx >= src.length) continue;
+      const distance = pos - idx;
+      const window = blackmanWindow(tap + radius - 1, taps);
+      const weight = cutoff * sinc(distance * cutoff) * window;
+      sum += src[idx] * weight;
+      weightSum += weight;
+    }
+    out[i] = weightSum ? (sum / weightSum) : 0;
+  }
+  return out;
+}
+
+function encodeLpcm16Mono(input) {
+  const pcm = coerceFloat32(input);
+  const out = Buffer.alloc(pcm.length * 2);
+  for (let i = 0; i < pcm.length; i++) {
+    const v = Math.max(-1, Math.min(1, Number.isFinite(pcm[i]) ? pcm[i] : 0));
+    const s = v < 0 ? Math.round(v * 32768) : Math.round(v * 32767);
+    out.writeInt16LE(Math.max(-32768, Math.min(32767, s)), i * 2);
+  }
+  return out;
+}
+
+function encodeLpcm16DuplicatedStereo(input) {
+  const pcm = coerceFloat32(input);
+  const out = Buffer.alloc(pcm.length * 4);
+  for (let i = 0; i < pcm.length; i++) {
+    const v = Math.max(-1, Math.min(1, Number.isFinite(pcm[i]) ? pcm[i] : 0));
+    const s = v < 0 ? Math.round(v * 32768) : Math.round(v * 32767);
+    const sample = Math.max(-32768, Math.min(32767, s));
+    const off = i * 4;
+    out.writeInt16LE(sample, off);
+    out.writeInt16LE(sample, off + 2);
+  }
+  return out;
+}
+
+function lpcm16ChannelCount(codec) {
+  return codec === AUDIO_CODEC_LPCM16_STEREO ? 2 : 1;
+}
+
+function analyzePcmFloat32(samples) {
+  const pcm = coerceFloat32(samples);
+  let peak = 0;
+  let sumSq = 0;
+  let nonZero = 0;
+  for (let i = 0; i < pcm.length; i++) {
+    const v = Number.isFinite(pcm[i]) ? pcm[i] : 0;
+    const a = Math.abs(v);
+    if (a > peak) peak = a;
+    if (a > 1e-6) nonZero++;
+    sumSq += v * v;
+  }
+  return {
+    peak,
+    rms: pcm.length ? Math.sqrt(sumSq / pcm.length) : 0,
+    nonZero,
+  };
+}
+
+function hex(buf) {
+  return Array.from(buf || []).map((b) => b.toString(16).padStart(2, '0').toUpperCase()).join(' ');
 }
 
 // ---------------------------------------------------------------------------
@@ -248,52 +643,85 @@ function buildCivData(seq, sentid, rcvdid, sendSeqB, civPayload) {
 // send/receive plumbing is shared.
 // ---------------------------------------------------------------------------
 class IcomUdpStream extends EventEmitter {
-  constructor({ name, host, port, log }) {
+  constructor({ name, host, port, localPort = 0, localAddress = null, deriveStreamId = true, trackedIdle = true, displayHost, log }) {
     super();
     this.name = name;
     this.host = host;
+    this.displayHost = displayHost || host;
     this.port = port;
+    this.localPort = localPort || 0;
+    this.localAddress = localAddress || null;
+    this.deriveStreamId = deriveStreamId !== false;
+    this.trackedIdle = trackedIdle !== false;
     this._log = log || (() => {});
     this.socket = null;
     this.myId = randomId();
     this.remoteId = 0;
     this.seq = 0;
+    this.pingSeq = 0;
+    this.txSeqBuf = new Map();
+    this.txRetransmitResentAt = new Map();
     this.aytTimer = null;
     this.pingTimer = null;
     this.idleTimer = null;
     this.connected = false;
     this.gotIAmHere = false;
+    this.aytCount = 0;
+    this.lastSendError = null;
   }
 
   open() {
+    if (this.socket) return Promise.resolve();
     return new Promise((resolve, reject) => {
       const sock = dgram.createSocket('udp4');
+      let settled = false;
+      const fail = (err) => {
+        if (!settled) {
+          settled = true;
+          reject(err);
+        }
+      };
       sock.on('error', (err) => {
         this._log(`[rsba1/${this.name}] socket error: ${err.message}`);
         this.emit('error', err);
       });
-      sock.on('message', (msg) => this._onMessage(msg));
-      sock.bind(0, () => {
+      sock.on('message', (msg, rinfo) => this._onMessage(msg, rinfo));
+      sock.bind(this.localPort, () => {
+        if (settled) return;
+        settled = true;
         this.socket = sock;
-        this._log(`[rsba1/${this.name}] bound on local port ${sock.address().port}`);
+        const bound = sock.address();
+        this.localPort = bound.port;
+        if (this.deriveStreamId) {
+          const idAddress = this.localAddress || (bound.address && bound.address !== '0.0.0.0' ? bound.address : null);
+          this.myId = streamIdFromLocalAddress(idAddress, this.localPort);
+        }
+        this._log(`[rsba1/${this.name}] bound on ${bound.address}:${this.localPort}; myId=0x${this.myId.toString(16)}; target ${this.displayHost}:${this.port}`);
         resolve();
       });
-      sock.once('error', reject);
+      sock.once('error', fail);
     });
   }
 
   close() {
     this._stopTimers();
     if (this.socket) {
-      try {
-        // Best-effort disconnect packet so the radio releases the session.
-        this._sendControl(TYPE_DISCONNECT, 0);
-      } catch { /* ignore */ }
-      try { this.socket.close(); } catch { /* ignore */ }
+      const sock = this.socket;
       this.socket = null;
+      try {
+        // Best-effort release packets. Keep the UDP socket alive briefly so
+        // the kernel can actually put them on the wire before close().
+        this._sendOnSocket(sock, buildControl(TYPE_DISCONNECT, 0, this.myId, this.remoteId));
+        this._sendOnSocket(sock, buildControl(TYPE_DISCONNECT, 0, this.myId, this.remoteId));
+      } catch { /* ignore */ }
+      setTimeout(() => {
+        try { sock.close(); } catch { /* ignore */ }
+      }, 80);
     }
     this.connected = false;
     this.gotIAmHere = false;
+    this.txSeqBuf.clear();
+    this.txRetransmitResentAt.clear();
   }
 
   _stopTimers() {
@@ -304,9 +732,84 @@ class IcomUdpStream extends EventEmitter {
 
   _send(buf) {
     if (!this.socket) return;
-    this.socket.send(buf, this.port, this.host, (err) => {
-      if (err) this._log(`[rsba1/${this.name}] send error: ${err.message}`);
+    this._sendOnSocket(this.socket, buf);
+  }
+
+  _sendOnSocket(sock, buf) {
+    if (!sock) return;
+    const port = Number(this.port);
+    if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+      this.lastSendError = `invalid remote UDP port ${this.port}`;
+      this._log(`[rsba1/${this.name}] send skipped: ${this.lastSendError} for ${this.displayHost}`);
+      return;
+    }
+    try {
+      sock.send(buf, port, this.host, (err) => {
+        if (err) {
+          this.lastSendError = err.message || String(err);
+          this._log(`[rsba1/${this.name}] send error to ${this.displayHost}:${this.port}: ${this.lastSendError}`);
+        }
+      });
+    } catch (err) {
+      this.lastSendError = err.message || String(err);
+      this._log(`[rsba1/${this.name}] send error to ${this.displayHost}:${this.port}: ${this.lastSendError}`);
+    }
+  }
+
+  _learnRemoteEndpoint(rinfo) {
+    if (!rinfo || !Number.isInteger(rinfo.port) || rinfo.port <= 0 || rinfo.port > 65535) return;
+    if (Number(this.port) > 0 && Number(this.port) <= 65535) return;
+    this.port = rinfo.port;
+    if (rinfo.address) this.host = rinfo.address;
+    this._log(`[rsba1/${this.name}] learned remote UDP endpoint ${rinfo.address || this.displayHost}:${rinfo.port}`);
+  }
+
+  _sendTracked(buf) {
+    if (!buf || buf.length < 8) return;
+    const seq = this.seq & 0xffff;
+    const packet = Buffer.from(buf);
+    packet.writeUInt16LE(seq, 0x06);
+    this.seq = (this.seq + 1) & 0xffff;
+    this.txSeqBuf.set(seq, packet);
+    while (this.txSeqBuf.size > TX_BUFFER_LIMIT) {
+      const oldest = this.txSeqBuf.keys().next().value;
+      this.txSeqBuf.delete(oldest);
+    }
+    this._send(packet);
+    return seq;
+  }
+
+  _handleRetransmitRequest(msg) {
+    if (!msg || msg.length < CONTROL_SIZE) return false;
+    const type = msg.readUInt16LE(4);
+    if (type !== 0x01) return false;
+    const seqs = [];
+    if (msg.length === CONTROL_SIZE) {
+      seqs.push(msg.readUInt16LE(6));
+    } else {
+      for (let off = CONTROL_SIZE; off + 1 < msg.length; off += 2) {
+        seqs.push(msg.readUInt16LE(off));
+      }
+    }
+    seqs.forEach((seq) => {
+      const packet = this.txSeqBuf.get(seq);
+      if (packet) {
+        const now = Date.now();
+        const last = this.txRetransmitResentAt.get(seq) || 0;
+        if (now - last < TX_RETRANSMIT_DEDUPE_MS) return;
+        this.txRetransmitResentAt.set(seq, now);
+        while (this.txRetransmitResentAt.size > TX_BUFFER_LIMIT) {
+          const oldest = this.txRetransmitResentAt.keys().next().value;
+          this.txRetransmitResentAt.delete(oldest);
+        }
+        this._log(`[rsba1/${this.name}] <- retransmit request for seq ${seq}; resending`);
+        this._send(packet);
+      } else {
+        this._log(`[rsba1/${this.name}] <- retransmit request for unknown seq ${seq}; sending idle`);
+        this._send(buildControl(TYPE_IDLE, seq, this.myId, this.remoteId));
+      }
     });
+    return true;
   }
 
   _sendControl(type, seq) {
@@ -315,17 +818,24 @@ class IcomUdpStream extends EventEmitter {
 
   _sendPing() {
     const t = (Date.now() & 0xffffffff) >>> 0;
-    this._send(buildPing(this.seq++, this.myId, this.remoteId, t, false));
+    this._send(buildPing(this.pingSeq++, this.myId, this.remoteId, t, false));
   }
 
   _sendIdle() {
-    this._sendControl(TYPE_RETRANSMIT, this.seq++);
+    if (this.trackedIdle) {
+      this._sendTracked(buildControl(TYPE_IDLE, 0, this.myId, this.remoteId));
+    } else {
+      this._sendControl(TYPE_IDLE, this.seq++);
+    }
   }
 
   startHandshake() {
+    this._stopTimers();
+    this.gotIAmHere = false;
     // Spam AYT every AYT_PERIOD until IAmHere arrives.
     const sendAyt = () => {
-      this._log(`[rsba1/${this.name}] -> AreYouThere`);
+      this.aytCount++;
+      this._log(`[rsba1/${this.name}] -> AreYouThere #${this.aytCount}`);
       this._sendControl(TYPE_AYT, 0);
     };
     sendAyt();
@@ -339,7 +849,7 @@ class IcomUdpStream extends EventEmitter {
   }
 
   // Subclasses implement.
-  _onMessage(msg) { /* override */ }
+  _onMessage(msg, rinfo) { this._learnRemoteEndpoint(rinfo); /* override */ }
 }
 
 // ---------------------------------------------------------------------------
@@ -350,18 +860,36 @@ class IcomUdpStream extends EventEmitter {
 class ControlStream extends IcomUdpStream {
   constructor(opts) {
     super({ ...opts, name: 'control' });
+    this.owner = opts.owner || null;
     this.username = opts.username || '';
     this.password = opts.password || '';
     this.compName = opts.compName || 'POTACAT';
     this.devName  = opts.devName  || 'POTACAT-Radio';
+    this.enableRxAudio = opts.enableRxAudio === true;
+    this.enableTxAudio = opts.enableTxAudio === true;
+    this.rxAudioCodec = opts.rxAudioCodec || AUDIO_CODEC_LPCM16_MONO;
+    this.rxAudioSampleRate = opts.rxAudioSampleRate || 48000;
+    this.txAudioCodec = opts.txAudioCodec || AUDIO_CODEC_LPCM16_MONO;
+    this.txAudioSampleRate = opts.txAudioSampleRate || ICOM_AUDIO_TX_SAMPLE_RATE;
+    this.txAudioBufferMs = opts.txAudioBufferMs || DEFAULT_TX_AUDIO_BUFFER_MS;
+    this.civLocalPort = opts.civLocalPort || 0;
+    this.audioLocalPort = opts.audioLocalPort || 0;
     this.tokRequest = (Math.random() * 0xffff) & 0xffff;
     this.token = 0;
     this.innerSeq = 0;
     this.authStage = 'AYT';
+    this.radioInfo = null;
+    this.authMode = opts.authMode || 'direct';
+    this.authRetryTimer = null;
+    this.authRetryCount = 0;
+    this.lastAuth = null;
+    this.txAudioNegotiated = false;
   }
 
-  _onMessage(msg) {
+  _onMessage(msg, rinfo) {
+    this._learnRemoteEndpoint(rinfo);
     if (msg.length < 4) return;
+    if (msg.length >= CONTROL_SIZE && this._handleRetransmitRequest(msg)) return;
     const len = msg.readUInt32LE(0);
     if (len !== msg.length) {
       this._log(`[rsba1/${this.name}] length mismatch: header=${len} actual=${msg.length}`);
@@ -374,13 +902,89 @@ class ControlStream extends IcomUdpStream {
       case LOGIN_RESPONSE_SIZE: this._onLoginResponse(msg); break;
       case CONNINFO_SIZE: this._onConnInfoIn(msg); break;
       default:
+        if (isCapabilitiesPacket(msg)) {
+          this._onCapabilities(msg);
+          return;
+        }
         this._log(`[rsba1/${this.name}] <- unknown packet size ${msg.length}`);
+    }
+  }
+
+  _clearAuthRetry() {
+    if (this.authRetryTimer) {
+      clearInterval(this.authRetryTimer);
+      this.authRetryTimer = null;
+    }
+    this.authRetryCount = 0;
+  }
+
+  _trackAuthResend(stage, packet, label, seq, intervalMs = 1000, maxRetries = 8) {
+    this._clearAuthRetry();
+    const stored = Buffer.from(packet || []);
+    this.authRetryTimer = setInterval(() => {
+      if (this.authStage !== stage) {
+        this._clearAuthRetry();
+        return;
+      }
+      this.authRetryCount++;
+      if (this.lastAuth && this.lastAuth.stage === stage) {
+        this.lastAuth.retryCount = this.authRetryCount;
+      }
+      if (this.authRetryCount > maxRetries) {
+        this._log(`[rsba1/${this.name}] auth retry limit reached for ${label}`);
+        this._clearAuthRetry();
+        return;
+      }
+      this._log(`[rsba1/${this.name}] -> retry ${label} seq=${seq} #${this.authRetryCount}`);
+      this._send(stored);
+    }, intervalMs);
+  }
+
+  _sendAuthPacket(stage, label, buildPacket, meta = {}) {
+    this.authStage = stage;
+    let seq;
+    let packet;
+    if (this.authMode === 'tracked') {
+      seq = this._sendTracked(buildPacket(0));
+      packet = this.txSeqBuf.get(seq);
+    } else {
+      seq = this.seq & 0xffff;
+      packet = buildPacket(seq);
+      this.seq = (this.seq + 1) & 0xffff;
+      this._send(packet);
+    }
+    this.lastAuth = {
+      stage,
+      label,
+      mode: this.authMode,
+      seq,
+      innerSeq: meta.innerSeq,
+      tokRequest: this.tokRequest,
+      myId: this.myId,
+      remoteId: this.remoteId,
+      usernameLength: String(this.username || '').length,
+      passwordLength: String(this.password || '').length,
+      retryCount: 0,
+    };
+    this._log(`[rsba1/${this.name}] -> ${label} mode=${this.authMode} seq=${seq} innerSeq=${meta.innerSeq == null ? '-' : meta.innerSeq} myId=0x${this.myId.toString(16)} remoteId=0x${this.remoteId.toString(16)} tokReq=0x${this.tokRequest.toString(16)} userLen=${this.lastAuth.usernameLength} passLen=${this.lastAuth.passwordLength}`);
+    this._trackAuthResend(stage, packet, label, seq);
+    return seq;
+  }
+
+  _sendProtocolPacket(buildPacket) {
+    if (this.authMode === 'tracked') {
+      this._sendTracked(buildPacket(0));
+    } else {
+      const seq = this.seq & 0xffff;
+      this.seq = (this.seq + 1) & 0xffff;
+      this._send(buildPacket(seq));
     }
   }
 
   _onControl(msg) {
     const type = msg.readUInt16LE(4);
     const sentId = msg.readUInt32LE(8);
+    if (this._handleRetransmitRequest(msg)) return;
     if (type === TYPE_IAMHERE) {
       if (!this.gotIAmHere) {
         this.gotIAmHere = true;
@@ -390,14 +994,16 @@ class ControlStream extends IcomUdpStream {
         this.startKeepAlive();
         // Trigger AreYouReady to advance the state machine — radio responds
         // with IAmReady, which is our cue to send Login.
-        this._sendControl(TYPE_AYR_IAR, this.seq++);
+        const ayrSeq = this.authMode === 'tracked' ? 1 : this.seq++;
+        this._sendControl(TYPE_AYR_IAR, ayrSeq);
+        this._log(`[rsba1/${this.name}] -> AreYouReady mode=${this.authMode} seq=${ayrSeq}`);
         this.authStage = 'AYR_SENT';
       }
     } else if (type === TYPE_AYR_IAR) {
       this._log(`[rsba1/${this.name}] <- IAmReady — sending Login`);
-      this.authStage = 'LOGIN_SENT';
-      this._send(buildLogin(this.seq++, this.myId, this.remoteId,
-        this.innerSeq++, this.tokRequest, this.username, this.password, this.compName));
+      const innerSeq = this.innerSeq++;
+      this._sendAuthPacket('LOGIN_SENT', 'Login', (seq) => buildLogin(seq, this.myId, this.remoteId,
+        innerSeq, this.tokRequest, this.username, this.password, this.compName), { innerSeq });
     } else {
       this._log(`[rsba1/${this.name}] <- control type 0x${type.toString(16)}`);
     }
@@ -416,6 +1022,7 @@ class ControlStream extends IcomUdpStream {
   }
 
   _onLoginResponse(msg) {
+    this._clearAuthRetry();
     const tokRequest = msg.readUInt16LE(0x1a);
     const token = msg.readUInt32LE(0x1c);
     const errCode = msg.readUInt32LE(0x30);
@@ -430,25 +1037,29 @@ class ControlStream extends IcomUdpStream {
     }
     this.token = token;
     this._log(`[rsba1/${this.name}] <- LoginResponse OK (token=0x${this.token.toString(16)})`);
-    this.authStage = 'TOKEN_CONFIRM_SENT';
     // Confirm token (magic 0x02) then expect Status with stream ports.
-    this._send(buildToken(this.seq++, this.myId, this.remoteId,
-      this.innerSeq++, this.tokRequest, this.token, 0x02));
+    const innerSeq = this.innerSeq++;
+    this._sendAuthPacket('TOKEN_CONFIRM_SENT', 'TokenConfirm', (seq) => buildToken(seq, this.myId, this.remoteId,
+      innerSeq, this.tokRequest, this.token, 0x02), { innerSeq });
     // Schedule periodic token renewal.
     if (this.tokenTimer) clearInterval(this.tokenTimer);
     this.tokenTimer = setInterval(() => {
-      this._send(buildToken(this.seq++, this.myId, this.remoteId,
-        this.innerSeq++, this.tokRequest, this.token, 0x05));
+      const renewInnerSeq = this.innerSeq++;
+      this._sendProtocolPacket((seq) => buildToken(seq, this.myId, this.remoteId,
+        renewInnerSeq, this.tokRequest, this.token, 0x05));
     }, TOKEN_RENEWAL);
   }
 
   _onToken(msg) {
+    this._clearAuthRetry();
     const requestReply = msg.readUInt8(0x14);
     const requestType  = msg.readUInt8(0x15);
-    const innerType    = msg.readUInt16LE(0x04);
     const response     = msg.readUInt32LE(0x30);
     this._log(`[rsba1/${this.name}] <- Token (reqReply=${requestReply} reqType=0x${requestType.toString(16)} response=0x${response.toString(16)})`);
     if (response === 0xffffffff) {
+      this.remoteId = msg.readUInt32LE(0x08);
+      this.tokRequest = msg.readUInt16LE(0x1a);
+      this.token = msg.readUInt32LE(0x1c);
       // Radio asked us to (re)send ConnInfo to (re)establish streams.
       this._sendConnInfo();
     } else if (response === 0x00000000 && this.authStage === 'TOKEN_CONFIRM_SENT') {
@@ -457,15 +1068,47 @@ class ControlStream extends IcomUdpStream {
     }
   }
 
+  _onCapabilities(msg) {
+    this._clearAuthRetry();
+    const radios = parseCapabilities(msg);
+    if (!radios.length) {
+      this._log(`[rsba1/${this.name}] <- Capabilities packet contained no radios`);
+      return;
+    }
+    this.radioInfo = radios[0];
+    const civ = `0x${this.radioInfo.civAddress.toString(16).toUpperCase().padStart(2, '0')}`;
+    const mac = Array.from(this.radioInfo.macAddress || []).map((b) => b.toString(16).padStart(2, '0')).join(':');
+    this._log(`[rsba1/${this.name}] <- Capabilities (${radios.length} radio(s)); selected ${this.radioInfo.name || 'radio'} CIV=${civ} commoncap=0x${this.radioInfo.commoncap.toString(16)} rxMask=0x${this.radioInfo.rxSampleMask.toString(16)} txMask=0x${this.radioInfo.txSampleMask.toString(16)} mac=${mac}`);
+    if (this.authStage === 'TOKEN_CONFIRM_SENT') {
+      this._sendConnInfo();
+    }
+  }
+
   _sendConnInfo() {
-    this.authStage = 'CONNINFO_SENT';
-    // We don't bind specific civ/audio local ports yet — let the radio
-    // pick whatever it advertises in the Status reply.
-    this._send(buildConnInfo(this.seq++, this.myId, this.remoteId,
-      this.innerSeq++, this.tokRequest, this.token, this.username, this.devName, 0, 0));
+    // RS-BA1 needs to know the client-side ports before it assigns the
+    // matching radio-side stream ports in the Status reply.
+    const innerSeq = this.innerSeq++;
+    const txSupported = !this.radioInfo || this.radioInfo.txSampleMask > 1;
+    this.txAudioNegotiated = this.enableTxAudio && txSupported;
+    if (this.enableTxAudio && !txSupported) {
+      this._log(`[rsba1/${this.name}] radio capabilities report no TX audio sample rates; requesting RX-only audio`);
+    } else if (this.enableTxAudio) {
+      this._log(`[rsba1/${this.name}] requesting TX audio codec=0x${this.txAudioCodec.toString(16)} sampleRate=${this.txAudioSampleRate} bufferMs=${this.txAudioBufferMs}`);
+    }
+    this._sendAuthPacket('CONNINFO_SENT', 'ConnInfo', (seq) => buildConnInfo(seq, this.myId, this.remoteId,
+      innerSeq, this.tokRequest, this.token, this.username, this.devName, this.civLocalPort, this.audioLocalPort, {
+        enableRx: this.enableRxAudio,
+        enableTx: this.txAudioNegotiated,
+        rxCodec: this.rxAudioCodec,
+        rxSampleRate: this.rxAudioSampleRate,
+        txCodec: this.txAudioCodec,
+        txSampleRate: this.txAudioSampleRate,
+        txBufferMs: this.txAudioBufferMs,
+      }, this.radioInfo), { innerSeq });
   }
 
   _onStatus(msg) {
+    this._clearAuthRetry();
     const error = msg.readUInt32LE(0x30);
     const civPort   = msg.readUInt16BE(0x42); // big-endian
     const audioPort = msg.readUInt16BE(0x46);
@@ -474,10 +1117,19 @@ class ControlStream extends IcomUdpStream {
       this.emit('auth-failed', 'connection-rejected');
       return;
     }
+    if (error !== 0 && civPort <= 0) {
+      this.emit('error', makeRsba1Error(
+        `rsba1 radio rejected stream request: status error=0x${(error >>> 0).toString(16)} with no CI-V port assigned`,
+        'RSBA1_STATUS_REJECTED',
+        { ...(this.owner ? this.owner._handshakeDiagnostics() : {}), statusError: error >>> 0, statusErrorHex: `0x${(error >>> 0).toString(16)}` }
+      ));
+      return;
+    }
     if (civPort > 0) {
       this.authStage = 'AUTHED';
       this.connected = true;
-      this.emit('streams-ready', { civPort, audioPort });
+      this._log(`[rsba1/${this.name}] stream request accepted; TX audio ${this.txAudioNegotiated ? 'enabled' : 'disabled'}`);
+      this.emit('streams-ready', { civPort, audioPort, txAudioEnabled: this.txAudioNegotiated });
     }
   }
 
@@ -488,8 +1140,27 @@ class ControlStream extends IcomUdpStream {
   }
 
   close() {
+    this._clearAuthRetry();
     if (this.tokenTimer) { clearInterval(this.tokenTimer); this.tokenTimer = null; }
+    this._sendTokenRemoval();
     super.close();
+  }
+
+  _sendTokenRemoval() {
+    if (!this.socket || !this.gotIAmHere || !this.remoteId || !this.token) return;
+    for (let i = 0; i < 2; i++) {
+      const seq = this.seq & 0xffff;
+      const innerSeq = this.innerSeq++ & 0xffff;
+      const packet = buildToken(seq, this.myId, this.remoteId, innerSeq, this.tokRequest, this.token, 0x01);
+      this.seq = (this.seq + 1) & 0xffff;
+      this.txSeqBuf.set(seq, packet);
+      while (this.txSeqBuf.size > TX_BUFFER_LIMIT) {
+        const oldest = this.txSeqBuf.keys().next().value;
+        this.txSeqBuf.delete(oldest);
+      }
+      this._log(`[rsba1/${this.name}] -> TokenRemoval seq=${seq} innerSeq=${innerSeq}`);
+      this._sendOnSocket(this.socket, packet);
+    }
   }
 }
 
@@ -501,10 +1172,37 @@ class CivStream extends IcomUdpStream {
   constructor(opts) {
     super({ ...opts, name: 'civ' });
     this.sendSeqB = 0;
+    this.openTimer = null;
+    this.dataStarted = false;
   }
 
-  _onMessage(msg) {
+  close() {
+    this._stopOpenTimer();
+    super.close();
+  }
+
+  _stopOpenTimer() {
+    if (this.openTimer) {
+      clearInterval(this.openTimer);
+      this.openTimer = null;
+    }
+  }
+
+  _sendOpenCloseStart() {
+    this._sendTracked(buildOpenClose(0, this.myId, this.remoteId, false, 0x04, this.sendSeqB++));
+  }
+
+  _startOpenFlow() {
+    this._sendOpenCloseStart();
+    if (!this.openTimer) {
+      this.openTimer = setInterval(() => this._sendOpenCloseStart(), 100);
+    }
+  }
+
+  _onMessage(msg, rinfo) {
+    this._learnRemoteEndpoint(rinfo);
     if (msg.length < 4) return;
+    if (msg.length >= CONTROL_SIZE && this._handleRetransmitRequest(msg)) return;
     if (msg.length === CONTROL_SIZE) {
       const type = msg.readUInt16LE(4);
       const sentId = msg.readUInt32LE(8);
@@ -514,12 +1212,15 @@ class CivStream extends IcomUdpStream {
         if (this.aytTimer) { clearInterval(this.aytTimer); this.aytTimer = null; }
         this._log(`[rsba1/${this.name}] <- IAmHere (remoteId=0x${this.remoteId.toString(16)})`);
         this.startKeepAlive();
+        this._sendControl(TYPE_AYR_IAR, 1);
       } else if (type === TYPE_AYR_IAR) {
-        this._log(`[rsba1/${this.name}] <- IAmReady — sending OpenClose to start CI-V flow`);
+        this._log(`[rsba1/${this.name}] <- IAmReady — opening CI-V flow`);
         this.remoteId = sentId; // wfview re-saves remoteId here too
-        this._send(buildOpenClose(this.seq++, this.myId, this.remoteId, false, 0x01));
-        this.connected = true;
-        this.emit('ready');
+        this._startOpenFlow();
+        if (!this.connected) {
+          this.connected = true;
+          this.emit('ready');
+        }
       } else {
         this._log(`[rsba1/${this.name}] <- control type 0x${type.toString(16)}`);
       }
@@ -551,6 +1252,9 @@ class CivStream extends IcomUdpStream {
         return;
       }
       const civ = msg.slice(CIV_HEADER_SIZE, CIV_HEADER_SIZE + datalen);
+      this.dataStarted = true;
+      this._stopOpenTimer();
+      this._log(`[rsba1/${this.name}] <- CI-V ${hex(civ)}`);
       this.emit('civ-data', civ);
     }
   }
@@ -558,7 +1262,678 @@ class CivStream extends IcomUdpStream {
   // Send raw CI-V bytes (already a complete CI-V frame) to the radio.
   sendCiv(buf) {
     if (!this.connected || !buf || !buf.length) return;
-    this._send(buildCivData(this.seq++, this.myId, this.remoteId, this.sendSeqB++, buf));
+    this._log(`[rsba1/${this.name}] -> CI-V ${hex(buf)}`);
+    this._sendTracked(buildCivData(0, this.myId, this.remoteId, this.sendSeqB++, buf));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// AudioStream — handshakes on the audio port, emits decoded RX PCM, and can
+// pace generated LPCM16 mono TX audio into the radio.
+// ---------------------------------------------------------------------------
+class AudioStream extends IcomUdpStream {
+  constructor(opts) {
+    super({ ...opts, name: 'audio' });
+    this.rxCodec = opts.rxCodec || AUDIO_CODEC_LPCM16_MONO;
+    this.rxSampleRate = opts.rxSampleRate || 48000;
+    this.enableTxAudio = opts.enableTxAudio === true;
+    this.txCodec = opts.txCodec || AUDIO_CODEC_LPCM16_MONO;
+    this.txSampleRate = opts.txSampleRate || ICOM_AUDIO_TX_SAMPLE_RATE;
+    this.txAudioBufferMs = opts.txAudioBufferMs || DEFAULT_TX_AUDIO_BUFFER_MS;
+    this.sendSeqB = 0;
+    this.txAudioSeq = 0;
+    this.openTimer = null;
+    this.dataStarted = false;
+    this._txInFlight = null;
+    this._txTimer = null;
+    this._txDrainTimer = null;
+    // Streaming voice TX state (for real-time phone-mic → RS-BA1 audio).
+    // Separate from the batch _txInFlight path so both can be checked
+    // independently for "TX already in flight" guards.
+    this._voiceTxBuf = null;          // Float32Array ring buffer
+    this._voiceTxWriteIdx = 0;
+    this._voiceTxReadIdx = 0;
+    this._voiceTxAvail = 0;           // samples available to read
+    this._voiceTxActive = false;      // voice TX session running
+    this._voiceTxPttHeld = false;     // PTT is still held; false → drain and stop
+    this._voiceTxTimer = null;        // pacing setTimeout handle
+    this._voiceTxStartMs = 0;         // wall-clock when session started
+    this._voiceTxSamplesSent = 0;     // total samples sent (for pacing math)
+    this._voiceTxPauseIdleOnStop = false; // resume idle keepalive after voice TX
+    this.rxHighestSeq = null;
+    this.rxMissing = new Map();
+    this.rxRetransmitTimer = null;
+    this.rxMissingTotal = 0;
+    this.rxDuplicateTotal = 0;
+    this.rxLargeGapTotal = 0;
+    this.rxOlderSeqStreak = 0;
+  }
+
+  close() {
+    this.cancelTx();
+    this._stopOpenTimer();
+    this._stopRxRetransmitTimer();
+    super.close();
+  }
+
+  get txReady() {
+    return this.connected && this.enableTxAudio &&
+      (this.txCodec === AUDIO_CODEC_LPCM16_MONO || this.txCodec === AUDIO_CODEC_LPCM16_STEREO);
+  }
+
+  setTxEnabled(enabled) {
+    this.enableTxAudio = enabled === true;
+  }
+
+  _stopOpenTimer() {
+    if (this.openTimer) {
+      clearInterval(this.openTimer);
+      this.openTimer = null;
+    }
+  }
+
+  _stopRxRetransmitTimer() {
+    if (this.rxRetransmitTimer) {
+      clearInterval(this.rxRetransmitTimer);
+      this.rxRetransmitTimer = null;
+    }
+  }
+
+  _startRxRetransmitTimer() {
+    if (this.rxRetransmitTimer) return;
+    this.rxRetransmitTimer = setInterval(() => this._sendRxRetransmitRequests(), RX_RETRANSMIT_PERIOD);
+  }
+
+  _sendOpenCloseStart() {
+    this._sendTracked(buildOpenClose(0, this.myId, this.remoteId, false, 0x04, this.sendSeqB++));
+  }
+
+  _startOpenFlow() {
+    this._sendOpenCloseStart();
+    if (!this.openTimer) {
+      this.openTimer = setInterval(() => this._sendOpenCloseStart(), 100);
+    }
+    this._startRxRetransmitTimer();
+  }
+
+  _seqDistance(from, to) {
+    return ((to - from + 0x10000) & 0xffff);
+  }
+
+  _trackRxAudioPacket(seq) {
+    const packetSeq = Number(seq) & 0xffff;
+    const info = {
+      seq: packetSeq,
+      duplicate: false,
+      missingAdded: 0,
+      missingRecovered: false,
+      largeGap: false,
+      pendingMissing: this.rxMissing.size,
+      missingTotal: this.rxMissingTotal,
+      duplicateTotal: this.rxDuplicateTotal,
+      largeGapTotal: this.rxLargeGapTotal,
+    };
+
+    if (this.rxMissing.has(packetSeq)) {
+      this.rxMissing.delete(packetSeq);
+      info.missingRecovered = true;
+      this.rxOlderSeqStreak = 0;
+      info.pendingMissing = this.rxMissing.size;
+      info.missingTotal = this.rxMissingTotal;
+      info.duplicateTotal = this.rxDuplicateTotal;
+      info.largeGapTotal = this.rxLargeGapTotal;
+      return info;
+    }
+
+    if (this.rxHighestSeq == null) {
+      this.rxHighestSeq = packetSeq;
+      this.rxOlderSeqStreak = 0;
+      info.pendingMissing = this.rxMissing.size;
+      return info;
+    }
+
+    const forward = this._seqDistance(this.rxHighestSeq, packetSeq);
+    if (forward === 0) {
+      info.duplicate = true;
+      this.rxDuplicateTotal++;
+      this.rxOlderSeqStreak = 0;
+    } else if (forward < 0x8000) {
+      this.rxOlderSeqStreak = 0;
+      if (forward > RX_MISSING_LIMIT) {
+        info.largeGap = true;
+        this.rxLargeGapTotal++;
+        this.rxMissing.clear();
+      } else if (forward > 1) {
+        for (let i = 1; i < forward; i++) {
+          const missingSeq = (this.rxHighestSeq + i) & 0xffff;
+          if (!this.rxMissing.has(missingSeq)) {
+            this.rxMissing.set(missingSeq, 0);
+            info.missingAdded++;
+            this.rxMissingTotal++;
+          }
+        }
+      }
+      this.rxHighestSeq = packetSeq;
+    } else {
+      // Older packet outside the pending-missing map. It may be a late
+      // retransmission after we gave up; count it as a duplicate/late arrival.
+      // If this happens repeatedly immediately after connect/reopen, the
+      // radio likely started us near a wrapped/stale sequence. Resync rather
+      // than poisoning diagnostics and retransmit tracking for the whole run.
+      info.duplicate = true;
+      this.rxDuplicateTotal++;
+      this.rxOlderSeqStreak++;
+      if (this.rxOlderSeqStreak >= 4) {
+        info.duplicate = false;
+        this.rxDuplicateTotal = Math.max(0, this.rxDuplicateTotal - 1);
+        info.largeGap = true;
+        this.rxLargeGapTotal++;
+        this.rxHighestSeq = packetSeq;
+        this.rxMissing.clear();
+        this.rxOlderSeqStreak = 0;
+      }
+    }
+
+    if (this.rxMissing.size > RX_MISSING_LIMIT) {
+      info.largeGap = true;
+      this.rxLargeGapTotal++;
+      this.rxMissing.clear();
+    }
+
+    info.pendingMissing = this.rxMissing.size;
+    info.missingTotal = this.rxMissingTotal;
+    info.duplicateTotal = this.rxDuplicateTotal;
+    info.largeGapTotal = this.rxLargeGapTotal;
+    return info;
+  }
+
+  _sendRxRetransmitRequests() {
+    if (!this.connected || !this.socket || !this.rxMissing.size) return;
+    const requestSeqs = [];
+    for (const [seq, attempts] of this.rxMissing) {
+      if (attempts >= RX_RETRANSMIT_MAX_ATTEMPTS) {
+        this._log(`[rsba1/${this.name}] no response for missing RX packet seq=${seq}; giving up`);
+        this.rxMissing.delete(seq);
+        continue;
+      }
+      requestSeqs.push(seq);
+      this.rxMissing.set(seq, attempts + 1);
+      if (requestSeqs.length >= 12) break;
+    }
+    if (!requestSeqs.length) return;
+    if (requestSeqs.length === 1) {
+      this._log(`[rsba1/${this.name}] requesting missing RX packet seq=${requestSeqs[0]}`);
+      this._send(buildControl(TYPE_RETRANSMIT_REQUEST, requestSeqs[0], this.myId, this.remoteId));
+    } else {
+      this._log(`[rsba1/${this.name}] requesting ${requestSeqs.length} missing RX packet(s): ${requestSeqs.join(',')}`);
+      this._send(buildRetransmitRange(0, this.myId, this.remoteId, requestSeqs));
+    }
+  }
+
+  restartAudioFlow(reason = 'audio stall') {
+    if (!this.socket) return false;
+    this._log(`[rsba1/${this.name}] restarting audio flow: ${reason}`);
+    this.cancelTx();
+    this._stopOpenTimer();
+    this._stopRxRetransmitTimer();
+    this._stopTimers();
+    this.connected = false;
+    this.gotIAmHere = false;
+    this.dataStarted = false;
+    this.rxHighestSeq = null;
+    this.rxMissing.clear();
+    this.rxOlderSeqStreak = 0;
+    this.startHandshake();
+    return true;
+  }
+
+  _onMessage(msg, rinfo) {
+    this._learnRemoteEndpoint(rinfo);
+    if (msg.length < 4) return;
+    if (msg.length >= CONTROL_SIZE && this._handleRetransmitRequest(msg)) return;
+    if (msg.length === CONTROL_SIZE) {
+      const type = msg.readUInt16LE(4);
+      const sentId = msg.readUInt32LE(8);
+      if (type === TYPE_IAMHERE && !this.gotIAmHere) {
+        this.gotIAmHere = true;
+        this.remoteId = sentId;
+        if (this.aytTimer) { clearInterval(this.aytTimer); this.aytTimer = null; }
+        this._log(`[rsba1/${this.name}] <- IAmHere (remoteId=0x${this.remoteId.toString(16)})`);
+        this.startKeepAlive();
+        this._sendControl(TYPE_AYR_IAR, 1);
+      } else if (type === TYPE_AYR_IAR) {
+        this.remoteId = sentId;
+        this._log(`[rsba1/${this.name}] <- IAmReady — opening audio stream${this.enableTxAudio ? ' (RX/TX)' : ' (RX)'}`);
+        this._startOpenFlow();
+        if (!this.connected) {
+          this.connected = true;
+          this.emit('ready');
+        }
+      } else {
+        this._log(`[rsba1/${this.name}] <- control type 0x${type.toString(16)}`);
+      }
+      return;
+    }
+    if (msg.length === PING_SIZE) {
+      const type = msg.readUInt16LE(4);
+      const reply = msg.readUInt8(0x10);
+      if (type === TYPE_PING && reply === 0) {
+        const seq = msg.readUInt16LE(6);
+        const time = msg.readUInt32LE(0x11);
+        this._send(buildPing(seq, this.myId, this.remoteId, time, true));
+      }
+      return;
+    }
+    if (msg.length <= AUDIO_HEADER_SIZE) return;
+    const innerType = msg.readUInt16LE(0x04);
+    if (innerType === 0x01) return; // retransmit request, ignore for now
+    const declaredLen = msg.readUInt32LE(0x00);
+    if (declaredLen && declaredLen > msg.length) {
+      this._log(`[rsba1/${this.name}] <- truncated audio packet`);
+      return;
+    }
+    const datalen = msg.readUInt16BE(0x16);
+    const end = AUDIO_HEADER_SIZE + datalen;
+    if (end > msg.length) {
+      this._log(`[rsba1/${this.name}] <- truncated audio payload`);
+      return;
+    }
+    const packetSeq = msg.readUInt16LE(0x06);
+    const ident = msg.readUInt16LE(0x10);
+    const audioSeq = msg.readUInt16BE(0x12);
+    const rxTrack = this._trackRxAudioPacket(packetSeq);
+    const payload = msg.slice(AUDIO_HEADER_SIZE, end);
+    if (this.rxCodec !== AUDIO_CODEC_LPCM16_MONO) {
+      this._log(`[rsba1/${this.name}] <- unsupported RX audio codec 0x${this.rxCodec.toString(16)}`);
+      return;
+    }
+    if (payload.length < 2) return;
+    this.dataStarted = true;
+    this._stopOpenTimer();
+    this.emit('audio-frame', {
+      pcm: decodeLpcm16Mono(payload),
+      sampleRate: this.rxSampleRate,
+      packetSeq,
+      audioSeq,
+      ident,
+      payloadBytes: payload.length,
+      recvMs: Date.now(),
+      rxTrack,
+    });
+  }
+
+  sendTxAudio(samples, offsetMs = 0, inputSampleRate = 12000) {
+    let tailSilenceMs = TX_TAIL_SILENCE_MS;
+    let startDelayMs = TX_SLOT_AUDIO_START_MS;
+    if (offsetMs && typeof offsetMs === 'object') {
+      const opts = offsetMs;
+      offsetMs = opts.offsetMs || 0;
+      inputSampleRate = opts.inputSampleRate || opts.sampleRate || inputSampleRate;
+      if (opts.tailSilenceMs != null) tailSilenceMs = opts.tailSilenceMs;
+      if (opts.startDelayMs != null) startDelayMs = opts.startDelayMs;
+    }
+    return new Promise((resolve, reject) => {
+      if (!this.connected || !this.socket) {
+        return reject(new Error('RS-BA1 audio stream is not connected'));
+      }
+      if (!this.enableTxAudio) {
+        return reject(new Error('RS-BA1 TX audio was not negotiated with the radio'));
+      }
+      if (this.txCodec !== AUDIO_CODEC_LPCM16_MONO && this.txCodec !== AUDIO_CODEC_LPCM16_STEREO) {
+        return reject(new Error(`RS-BA1 TX codec 0x${this.txCodec.toString(16)} is not supported by this build`));
+      }
+      if (this._txInFlight) {
+        return reject(new Error('RS-BA1 TX audio already in flight'));
+      }
+      if (this._voiceTxActive) {
+        return reject(new Error('RS-BA1 voice TX is active — stop voice TX before sending batch audio'));
+      }
+      const src = coerceFloat32(samples);
+      if (!src.length) {
+        return reject(new Error('samples must be a non-empty Float32Array'));
+      }
+      const txRate = this.txSampleRate || ICOM_AUDIO_TX_SAMPLE_RATE;
+      const negotiatedBufferMs = Math.max(0, Number(this.txAudioBufferMs) || DEFAULT_TX_AUDIO_BUFFER_MS);
+      const paceLeadMs = Math.max(0, Math.min(TX_MAX_PACE_LEAD_MS, negotiatedBufferMs - TX_BUFFER_SAFETY_MS));
+      const resampled = resampleMonoFloat32(src, inputSampleRate || txRate, txRate);
+      const leadSamples = Math.max(0, Math.round((clampStartDelayMs(startDelayMs) - (Number(offsetMs) || 0)) / 1000 * txRate));
+      const tailSamples = Math.max(0, Math.round(clampTailSilenceMs(tailSilenceMs) / 1000 * txRate));
+      let txPcm = resampled;
+      if (leadSamples > 0 || tailSamples > 0) {
+        txPcm = new Float32Array(leadSamples + resampled.length + tailSamples);
+        txPcm.set(resampled, leadSamples);
+      }
+      const srcStats = analyzePcmFloat32(src);
+      const resampledStats = analyzePcmFloat32(resampled);
+      const txChannels = lpcm16ChannelCount(this.txCodec);
+      const payload = txChannels === 2 ? encodeLpcm16DuplicatedStereo(txPcm) : encodeLpcm16Mono(txPcm);
+      const bytesPerAudioFrame = 2 * txChannels;
+      const frameBytes = Math.max(bytesPerAudioFrame, Math.round(txRate * AUDIO_FRAME_PERIOD_MS / 1000) * bytesPerAudioFrame);
+      const totalFrames = Math.ceil(payload.length / frameBytes);
+      let totalPackets = 0;
+      for (let pos = 0; pos < payload.length; pos += frameBytes) {
+        totalPackets += Math.ceil(Math.min(frameBytes, payload.length - pos) / AUDIO_TX_MAX_PAYLOAD);
+      }
+      this._log(`[rsba1/${this.name}] TX audio start: ${src.length} samples @${inputSampleRate || txRate} Hz -> ${txPcm.length} samples @${txRate} Hz, ${totalFrames} frame(s) @${AUDIO_FRAME_PERIOD_MS}ms split into ${totalPackets} UDP audio packet(s), lead=${leadSamples}, tail=${tailSamples}, startDelay=${clampStartDelayMs(startDelayMs)}ms, buffer=${negotiatedBufferMs}ms, paceLead=${paceLeadMs}ms, srcPeak=${srcStats.peak.toFixed(4)} srcRms=${srcStats.rms.toFixed(4)} srcNonZero=${srcStats.nonZero}, txPeak=${resampledStats.peak.toFixed(4)} txRms=${resampledStats.rms.toFixed(4)} txNonZero=${resampledStats.nonZero}`);
+      const pausedIdleTimer = this.idleTimer;
+      if (pausedIdleTimer) {
+        clearInterval(pausedIdleTimer);
+        this.idleTimer = null;
+        this._log(`[rsba1/${this.name}] pausing idle keepalive during TX audio`);
+      }
+      const audioMs = txPcm.length / txRate * 1000;
+      this._txInFlight = {
+        payload,
+        bytePos: 0,
+        samplesSent: 0,
+        framesSent: 0,
+        packetsSent: 0,
+        totalFrames,
+        totalPackets,
+        frameBytes,
+        bytesPerAudioFrame,
+        txChannels,
+        sampleRate: txRate,
+        paceLeadMs,
+        startMs: Date.now(),
+        lastPumpMs: Date.now(),
+        maxPumpGapMs: 0,
+        drainTimer: null,
+        hardTimer: null,
+        resumeIdleAfterTx: !!pausedIdleTimer,
+        resolve,
+        reject,
+      };
+      this._txInFlight.hardTimer = setTimeout(() => {
+        const q = this._txInFlight;
+        if (!q) return;
+        this._txInFlight = null;
+        if (this._txTimer) {
+          clearTimeout(this._txTimer);
+          this._txTimer = null;
+        }
+        if (this._txDrainTimer) {
+          clearTimeout(this._txDrainTimer);
+          this._txDrainTimer = null;
+        }
+        this._log(`[rsba1/${this.name}] TX audio watchdog fired at frame ${q.framesSent}/${q.totalFrames}, packet ${q.packetsSent}/${q.totalPackets}`);
+        this._resumeIdleAfterTx(q);
+        try { q.reject(new Error('RS-BA1 TX audio watchdog timeout')); } catch { /* ignore */ }
+      }, Math.max(5000, Math.ceil(audioMs + paceLeadMs + 3000)));
+      this._pumpTxAudio();
+    });
+  }
+
+  cancelTx() {
+    if (this._txTimer) {
+      clearTimeout(this._txTimer);
+      this._txTimer = null;
+    }
+    if (this._txDrainTimer) {
+      clearTimeout(this._txDrainTimer);
+      this._txDrainTimer = null;
+    }
+    if (this._txInFlight) {
+      const q = this._txInFlight;
+      if (q.drainTimer) {
+        clearTimeout(q.drainTimer);
+        q.drainTimer = null;
+      }
+      if (q.hardTimer) {
+        clearTimeout(q.hardTimer);
+        q.hardTimer = null;
+      }
+      this._txInFlight = null;
+      this._log(`[rsba1/${this.name}] TX audio cancelled at frame ${q.framesSent}/${q.totalFrames}, packet ${q.packetsSent}/${q.totalPackets}`);
+      this._resumeIdleAfterTx(q);
+      try { q.reject(new Error('TX cancelled')); } catch { /* ignore */ }
+    }
+    // Also cancel any in-progress voice TX (e.g. operator switch during phone voice TX).
+    this._stopVoiceTx('cancelled');
+  }
+
+  _resumeIdleAfterTx(q) {
+    if (!q || !q.resumeIdleAfterTx || this.idleTimer || !this.socket || !this.gotIAmHere) return;
+    this.idleTimer = setInterval(() => this._sendIdle(), IDLE_PERIOD);
+    this._log(`[rsba1/${this.name}] resumed idle keepalive after TX audio`);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Streaming voice TX — for real-time phone-mic audio over ECHOCAT.
+  // Unlike sendTxAudio() (which takes a pre-rendered buffer), this path keeps
+  // a ring buffer that main.js fills with IPC chunks from the phone's mic
+  // WorkLet while PTT is held.  The same pacing model as batch TX applies:
+  // frames are sent up to paceLeadMs ms ahead of real-time so the radio's
+  // internal TX buffer never runs empty.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Start a streaming voice TX session.  Must be called before pushVoiceChunk().
+   * Throws synchronously if TX is not ready or another TX is already in flight.
+   */
+  startVoiceTx() {
+    if (!this.connected || !this.socket) throw new Error('RS-BA1 audio stream not connected');
+    if (!this.enableTxAudio)              throw new Error('RS-BA1 TX audio was not negotiated');
+    if (this._txInFlight)                 throw new Error('RS-BA1 batch TX is in flight');
+    if (this._voiceTxActive)              throw new Error('RS-BA1 voice TX already active');
+
+    // Pause idle keepalive for the duration of TX.
+    const hadIdle = !!this.idleTimer;
+    if (hadIdle) {
+      clearInterval(this.idleTimer);
+      this.idleTimer = null;
+      this._log(`[rsba1/${this.name}] pausing idle keepalive during voice TX`);
+    }
+
+    this._voiceTxBuf    = new Float32Array(VOICE_TX_RING_SAMPLES);
+    this._voiceTxWriteIdx  = 0;
+    this._voiceTxReadIdx   = 0;
+    this._voiceTxAvail     = 0;
+    this._voiceTxActive    = true;
+    this._voiceTxPttHeld   = true;
+    this._voiceTxStartMs   = Date.now();
+    this._voiceTxSamplesSent = 0;
+    this._voiceTxPauseIdleOnStop = hadIdle;
+
+    const txRate = this.txSampleRate || ICOM_AUDIO_TX_SAMPLE_RATE;
+    this._log(`[rsba1/${this.name}] voice TX start — streaming at ${txRate} Hz, ${VOICE_TX_FRAME_SAMPLES} samples/frame (${VOICE_TX_FRAME_SAMPLES / txRate * 1000} ms)`);
+
+    this._voiceTxPump();
+  }
+
+  /**
+   * Append samples to the voice TX ring buffer.  Silently dropped if voice TX
+   * is not active or if the ring buffer overflows (oldest samples discarded).
+   * @param {Float32Array} samples — 48 kHz mono float32 mic audio
+   */
+  pushVoiceChunk(samples) {
+    if (!this._voiceTxActive || !this._voiceTxBuf) return;
+    const buf    = this._voiceTxBuf;
+    const bufLen = buf.length;
+    const len    = samples.length;
+    for (let i = 0; i < len; i++) {
+      buf[this._voiceTxWriteIdx] = samples[i];
+      this._voiceTxWriteIdx = (this._voiceTxWriteIdx + 1) % bufLen;
+      if (this._voiceTxAvail < bufLen) {
+        this._voiceTxAvail++;
+      } else {
+        // Overflow — advance read pointer, discard oldest sample.
+        this._voiceTxReadIdx = (this._voiceTxReadIdx + 1) % bufLen;
+      }
+    }
+  }
+
+  /**
+   * Signal that the phone's PTT has been released.  The pump will drain any
+   * remaining buffered audio then stop and resume the idle keepalive.
+   */
+  stopVoiceTx() {
+    if (!this._voiceTxActive) return;
+    this._voiceTxPttHeld = false;
+    this._log(`[rsba1/${this.name}] voice TX PTT released — draining ${this._voiceTxAvail} remaining samples`);
+    // Pump notices _voiceTxPttHeld===false and stops when buffer empty.
+  }
+
+  /** Internal: pacing pump for voice TX. Mirrors _pumpTxAudio() cadence. */
+  _voiceTxPump() {
+    if (!this._voiceTxActive) return;
+    if (!this.connected || !this.socket) {
+      this._stopVoiceTx('disconnected');
+      return;
+    }
+
+    const txRate   = this.txSampleRate || ICOM_AUDIO_TX_SAMPLE_RATE;
+    const txCh     = lpcm16ChannelCount(this.txCodec);
+    const negotiatedBufferMs = Math.max(0, Number(this.txAudioBufferMs) || DEFAULT_TX_AUDIO_BUFFER_MS);
+    const paceLeadMs = Math.max(0, Math.min(TX_MAX_PACE_LEAD_MS, negotiatedBufferMs - TX_BUFFER_SAFETY_MS));
+
+    // Send as many frames as the pacing window allows.
+    while (true) {
+      const scheduledMs = this._voiceTxSamplesSent / txRate * 1000;
+      const elapsedMs   = Date.now() - this._voiceTxStartMs;
+      if (scheduledMs > elapsedMs + paceLeadMs) break; // ahead of real-time
+
+      if (this._voiceTxAvail < VOICE_TX_FRAME_SAMPLES) {
+        // Buffer underrun.
+        if (!this._voiceTxPttHeld) {
+          // PTT released and buffer drained — done.
+          this._log(`[rsba1/${this.name}] voice TX drain complete (${this._voiceTxSamplesSent} samples sent)`);
+          this._stopVoiceTx('done');
+          return;
+        }
+        // Still holding PTT; send a silence frame to keep the radio's
+        // TX buffer from starving during brief IPC jitter.
+        const silence = new Float32Array(VOICE_TX_FRAME_SAMPLES);
+        this._sendVoiceFrame(silence, txCh);
+        this._voiceTxSamplesSent += VOICE_TX_FRAME_SAMPLES;
+        continue;
+      }
+
+      // Dequeue one frame from the ring buffer.
+      const frame  = new Float32Array(VOICE_TX_FRAME_SAMPLES);
+      const buf    = this._voiceTxBuf;
+      const bufLen = buf.length;
+      for (let i = 0; i < VOICE_TX_FRAME_SAMPLES; i++) {
+        frame[i] = buf[this._voiceTxReadIdx];
+        this._voiceTxReadIdx = (this._voiceTxReadIdx + 1) % bufLen;
+      }
+      this._voiceTxAvail -= VOICE_TX_FRAME_SAMPLES;
+      this._sendVoiceFrame(frame, txCh);
+      this._voiceTxSamplesSent += VOICE_TX_FRAME_SAMPLES;
+    }
+
+    // Schedule next pump tick to fire when the next frame is due.
+    const scheduledMs  = this._voiceTxSamplesSent / txRate * 1000;
+    const sleepMs      = Math.max(1, scheduledMs - (Date.now() - this._voiceTxStartMs) - paceLeadMs);
+    this._voiceTxTimer = setTimeout(() => this._voiceTxPump(), sleepMs);
+  }
+
+  /** Encode + send one voice frame (Float32 mono → LPCM16, split into UDP chunks). */
+  _sendVoiceFrame(frame, txChannels) {
+    const payload = txChannels === 2
+      ? encodeLpcm16DuplicatedStereo(frame)
+      : encodeLpcm16Mono(frame);
+    let bytePos = 0;
+    while (bytePos < payload.length) {
+      const len     = Math.min(AUDIO_TX_MAX_PAYLOAD, payload.length - bytePos);
+      const chunk   = payload.slice(bytePos, bytePos + len);
+      const audioSeq = this.txAudioSeq & 0xffff;
+      this.txAudioSeq = (this.txAudioSeq + 1) & 0xffff;
+      this._sendTracked(buildAudioData(0, this.myId, this.remoteId, audioSeq, chunk));
+      bytePos += len;
+    }
+  }
+
+  /** Internal: tear down the voice TX session unconditionally. */
+  _stopVoiceTx(reason = 'stop') {
+    if (!this._voiceTxActive) return;
+    this._voiceTxActive   = false;
+    this._voiceTxPttHeld  = false;
+    if (this._voiceTxTimer) {
+      clearTimeout(this._voiceTxTimer);
+      this._voiceTxTimer = null;
+    }
+    const secSent = (this._voiceTxSamplesSent / (this.txSampleRate || ICOM_AUDIO_TX_SAMPLE_RATE)).toFixed(2);
+    this._log(`[rsba1/${this.name}] voice TX stopped (${reason}) — ${this._voiceTxSamplesSent} samples / ${secSent}s sent`);
+    this._voiceTxBuf   = null;
+    const hadIdle      = this._voiceTxPauseIdleOnStop;
+    this._voiceTxPauseIdleOnStop = false;
+    if (hadIdle) this._resumeIdleAfterTx({ resumeIdleAfterTx: true });
+  }
+
+  _sendTxAudioFrame(q) {
+    const frameStart = q.bytePos;
+    const frameEnd = Math.min(q.payload.length, frameStart + q.frameBytes);
+
+    while (q.bytePos < frameEnd) {
+      const len = Math.min(AUDIO_TX_MAX_PAYLOAD, frameEnd - q.bytePos);
+      const chunk = q.payload.slice(q.bytePos, q.bytePos + len);
+      const audioSeq = this.txAudioSeq & 0xffff;
+      this.txAudioSeq = (this.txAudioSeq + 1) & 0xffff;
+      this._sendTracked(buildAudioData(0, this.myId, this.remoteId, audioSeq, chunk));
+      q.bytePos += len;
+      q.packetsSent++;
+    }
+
+    q.samplesSent += (frameEnd - frameStart) / q.bytesPerAudioFrame;
+    q.framesSent++;
+  }
+
+  _pumpTxAudio() {
+    const q = this._txInFlight;
+    if (!q) return;
+    if (!this.connected || !this.socket) {
+      this._txInFlight = null;
+      if (q.hardTimer) {
+        clearTimeout(q.hardTimer);
+        q.hardTimer = null;
+      }
+      try { q.reject(new Error('RS-BA1 audio disconnected mid-TX')); } catch { /* ignore */ }
+      return;
+    }
+
+    let framesThisTick = 0;
+    const now = Date.now();
+    if (q.lastPumpMs) q.maxPumpGapMs = Math.max(q.maxPumpGapMs || 0, now - q.lastPumpMs);
+    q.lastPumpMs = now;
+
+    while (q.bytePos < q.payload.length) {
+      const scheduledMs = q.samplesSent / q.sampleRate * 1000;
+      const elapsedMs = Date.now() - q.startMs;
+      if (framesThisTick >= MAX_TX_FRAMES_PER_PUMP) break;
+      if (q.framesSent > 0 && scheduledMs > elapsedMs + q.paceLeadMs) break;
+
+      // wfview gathers one AUDIO_PERIOD-sized audio block, then splits that
+      // block into 1364-byte UDP chunks immediately. Keep the 20ms cadence at
+      // the frame level rather than spacing individual UDP chunks apart.
+      this._sendTxAudioFrame(q);
+      framesThisTick++;
+    }
+
+    if (q.bytePos >= q.payload.length) {
+      const elapsed = Date.now() - q.startMs;
+      const audioMs = q.samplesSent / q.sampleRate * 1000;
+      const drainMs = Math.max(0, Math.round(audioMs - elapsed));
+      this._log(`[rsba1/${this.name}] TX audio queued ${q.framesSent} frame(s), ${q.packetsSent} packet(s) in ${elapsed} ms; drain=${drainMs}ms maxPumpGap=${Math.round(q.maxPumpGapMs || 0)}ms`);
+      this._txTimer = null;
+      this._txDrainTimer = q.drainTimer = setTimeout(() => {
+        if (this._txInFlight !== q) return;
+        this._txInFlight = null;
+        this._txDrainTimer = null;
+        if (q.hardTimer) {
+          clearTimeout(q.hardTimer);
+          q.hardTimer = null;
+        }
+        q.drainTimer = null;
+        this._resumeIdleAfterTx(q);
+        try { q.resolve(); } catch { /* ignore */ }
+      }, drainMs);
+      return;
+    }
+
+    const nextScheduledMs = q.samplesSent / q.sampleRate * 1000;
+    const sleepMs = Math.max(0, nextScheduledMs - (Date.now() - q.startMs) - q.paceLeadMs);
+    this._txTimer = setTimeout(() => this._pumpTxAudio(), sleepMs);
   }
 }
 
@@ -568,63 +1943,200 @@ class CivStream extends IcomUdpStream {
 //   .disconnect()
 //   .write(buf)        — feed CI-V bytes; routed to civ stream
 //   .setPin(...)       — no-op (UDP transport has no DTR/RTS)
-//   events: 'connect', 'data' (CI-V bytes), 'close', 'error', 'log'
+//   events: 'connect', 'data' (CI-V bytes), 'audio-frame', 'close', 'error',
+//           'log'
 // ---------------------------------------------------------------------------
 class RsBa1Transport extends EventEmitter {
   constructor() {
     super();
     this.control = null;
     this.civ = null;
+    this.audio = null;
     this._target = null;
     this._connected = false;
     this._handshakeDeadline = null;
+    this._connectToken = 0;
+    this._handshakeStage = 'idle';
+    this._civFallbackTimer = null;
+    this._assignedCivPort = null;
+    this._triedCivFallback = false;
   }
 
-  get connected() { return this._connected; }
-  get isOpen()    { return this._connected; }
+  get connected()      { return this._connected; }
+  get isOpen()         { return this._connected; }
+  get txReady()        { return !!(this.audio && this.audio.txReady); }
+  get voiceTxActive()  { return !!(this.audio && this.audio._voiceTxActive); }
 
-  connect({ host, controlPort = 50001, civPort, username = '', password = '', compName = 'POTACAT' } = {}) {
+  /** Start streaming voice TX.  Throws if TX not ready or another TX in flight. */
+  startVoiceTx() {
+    if (!this.audio) throw new Error('RS-BA1 audio stream not connected');
+    this.audio.startVoiceTx();
+  }
+  /** Push Float32 mic samples into the voice TX ring buffer. */
+  pushVoiceChunk(samples) {
+    if (this.audio) this.audio.pushVoiceChunk(samples);
+  }
+  /** Release voice TX PTT — pump drains remaining buffer then stops. */
+  stopVoiceTx() {
+    if (this.audio) this.audio.stopVoiceTx();
+  }
+
+  connect({ host, controlPort = 50001, civPort, username = '', password = '', compName = 'POTACAT', enableRxAudio = false, enableTxAudio = false, rxAudioCodec = AUDIO_CODEC_LPCM16_MONO, rxAudioSampleRate = 48000, txAudioCodec = AUDIO_CODEC_LPCM16_MONO, txAudioSampleRate = ICOM_AUDIO_TX_SAMPLE_RATE, txAudioBufferMs = DEFAULT_TX_AUDIO_BUFFER_MS, controlAuthMode = 'direct', timeoutMs = HANDSHAKE_TIMEOUT } = {}) {
     if (!host) {
       this.emit('error', new Error('rsba1: host is required'));
       return;
     }
     this.disconnect();
-    this._target = { host, controlPort, civPort: civPort || null, username, password, compName };
+    const connectToken = ++this._connectToken;
+    const rawHost = String(host || '').trim();
+    this._target = {
+      host: rawHost,
+      resolvedHost: null,
+      controlPort,
+      civPort: civPort || null,
+      username,
+      password,
+      compName,
+      enableRxAudio: enableRxAudio === true,
+      enableTxAudio: enableTxAudio === true,
+      rxAudioCodec,
+      rxAudioSampleRate,
+      txAudioCodec,
+      txAudioSampleRate,
+      txAudioBufferMs,
+      controlAuthMode,
+      timeoutMs,
+      civLocalPort: 0,
+      audioLocalPort: 0,
+      localAddress: null,
+    };
     const log = (msg) => this.emit('log', msg);
 
-    this.control = new ControlStream({ host, port: controlPort, username, password, compName, log });
+    this._handshakeStage = 'resolving-host';
+    this._startHandshakeWatchdog(timeoutMs);
 
-    this.control.on('error', (e) => this.emit('error', e));
-    this.control.on('auth-failed', (reason) => {
-      this.emit('error', new Error(`rsba1 authentication failed: ${reason}`));
-      this.disconnect();
-    });
-    this.control.on('streams-ready', ({ civPort: assignedCivPort }) => {
-      // Open civ stream on the port the radio assigned (or the override).
-      const targetCivPort = this._target.civPort || assignedCivPort || (controlPort + 1);
-      this._openCivStream(host, targetCivPort, log);
-    });
+    dns.lookup(rawHost, { family: 4 })
+      .then(async ({ address, family }) => {
+        if (connectToken !== this._connectToken) return;
+        const targetHost = address || rawHost;
+        this._target.resolvedHost = targetHost;
+        log(`[rsba1] resolved ${rawHost} -> ${targetHost} (IPv${family || 4})`);
+        const displayHost = rawHost === targetHost ? targetHost : `${rawHost} (${targetHost})`;
+        const localSelection = await findLocalAddressForTarget(targetHost, controlPort);
+        if (connectToken !== this._connectToken) return;
+        const localAddress = localSelection && localSelection.address ? localSelection.address : null;
+        this._target.localAddress = localAddress;
+        if (localAddress) {
+          const source = localSelection.source === 'same-subnet' ? 'same-subnet' : 'routed';
+          const iface = localSelection.interfaceName ? ` on ${localSelection.interfaceName}` : '';
+          const routed = localSelection.routedAddress && localSelection.routedAddress !== localAddress
+            ? ` (OS route was ${localSelection.routedAddress})`
+            : '';
+          log(`[rsba1] using ${source} local IPv4 ${localAddress}${iface} for wfview-style stream IDs${routed}`);
+        } else {
+          log('[rsba1] could not determine routed local IPv4; using OS default UDP bind');
+        }
+        try {
+          this._handshakeStage = 'opening-data-streams';
+          this._prepareCivStream(targetHost, displayHost, localAddress, log);
+          await this.civ.open();
+          this._target.civLocalPort = this.civ.localPort;
+          if (this._target.enableRxAudio || this._target.enableTxAudio) {
+            this._prepareAudioStream(targetHost, displayHost, 0, localAddress, log);
+            await this.audio.open();
+            this._target.audioLocalPort = this.audio.localPort;
+          }
+        } catch (err) {
+          if (connectToken !== this._connectToken) return;
+          this.emit('error', makeRsba1Error(`rsba1 could not open local UDP stream sockets: ${err.message || err}`, 'RSBA1_LOCAL_PORT_FAILED', this._handshakeDiagnostics()));
+          this.disconnect();
+          return;
+        }
+        if (connectToken !== this._connectToken) return;
+        log(`[rsba1] opened client stream ports: civ=${this._target.civLocalPort} audio=${this._target.audioLocalPort || 0}`);
+        this._handshakeStage = 'opening-control';
 
-    this.control.open()
-      .then(() => this.control.startHandshake())
-      .catch((err) => this.emit('error', err));
+        this.control = new ControlStream({
+          host: targetHost,
+          displayHost,
+          port: controlPort,
+          localAddress,
+          deriveStreamId: false,
+          trackedIdle: controlAuthMode === 'tracked',
+          authMode: controlAuthMode,
+          username,
+          password,
+          compName,
+          owner: this,
+          log,
+          enableRxAudio,
+          enableTxAudio,
+          rxAudioCodec,
+          rxAudioSampleRate,
+          txAudioCodec,
+          txAudioSampleRate,
+          txAudioBufferMs,
+          civLocalPort: this._target.civLocalPort,
+          audioLocalPort: this._target.audioLocalPort,
+        });
 
-    // Handshake watchdog: if we don't authenticate within HANDSHAKE_TIMEOUT,
-    // give up and emit error so the upstream connector can show a useful
-    // message (rather than hang silently).
-    this._handshakeDeadline = setTimeout(() => {
-      if (!this._connected) {
-        this.emit('error', new Error('rsba1 handshake timed out (no IAmHere/Login response from radio)'));
+        this.control.on('error', (e) => this.emit('error', e));
+        this.control.on('auth-failed', (reason) => {
+          this.emit('error', makeRsba1Error(`rsba1 authentication failed: ${reason}`, 'RSBA1_AUTH_FAILED', {
+            reason,
+            ...this._handshakeDiagnostics(),
+          }));
+          this.disconnect();
+        });
+        this.control.on('streams-ready', ({ civPort: assignedCivPort, audioPort: assignedAudioPort, txAudioEnabled }) => {
+          if (connectToken !== this._connectToken) return;
+          this._target.enableTxAudio = txAudioEnabled === true;
+          if (this.audio) this.audio.setTxEnabled(this._target.enableTxAudio);
+          if (enableTxAudio && !this._target.enableTxAudio) {
+            log('[rsba1/audio] TX audio requested but not negotiated; direct TX audio will be unavailable');
+          }
+          // Open civ stream on the port the radio assigned (or the override).
+          const targetCivPort = this._target.civPort || assignedCivPort || (controlPort + 1);
+          this._startCivStream(targetCivPort, assignedCivPort || null);
+          if (this._target.enableRxAudio || this._target.enableTxAudio) {
+            const targetAudioPort = assignedAudioPort || 0;
+            if (targetAudioPort > 0) {
+              this._startAudioStream(targetAudioPort);
+            } else {
+              log('[rsba1/audio] radio did not advertise an audio port; waiting to learn it from inbound audio packets');
+              this._startAudioStream(0);
+            }
+          }
+        });
+
+        this.control.open()
+          .then(() => {
+            if (connectToken !== this._connectToken || !this.control) return;
+            this._handshakeStage = 'waiting-control-IAmHere';
+            this.control.startHandshake();
+          })
+          .catch((err) => this.emit('error', err));
+      })
+      .catch((err) => {
+        if (connectToken !== this._connectToken) return;
+        this.emit('error', makeRsba1Error(`rsba1 could not resolve host "${rawHost}" to an IPv4 address: ${err.message || err}`, 'RSBA1_DNS_FAILED', {
+          host: rawHost,
+          controlPort,
+        }));
         this.disconnect();
-      }
-    }, HANDSHAKE_TIMEOUT);
+      });
   }
 
-  _openCivStream(host, port, log) {
-    this.civ = new CivStream({ host, port, log });
+  _prepareCivStream(host, displayHost, localAddress, log) {
+    if (this.civ) return;
+    this.civ = new CivStream({ host, displayHost, port: 0, localAddress, log });
     this.civ.on('error', (e) => this.emit('error', e));
     this.civ.on('ready', () => {
       this._connected = true;
+      if (this._civFallbackTimer) {
+        clearTimeout(this._civFallbackTimer);
+        this._civFallbackTimer = null;
+      }
       if (this._handshakeDeadline) {
         clearTimeout(this._handshakeDeadline);
         this._handshakeDeadline = null;
@@ -634,22 +2146,189 @@ class RsBa1Transport extends EventEmitter {
     this.civ.on('civ-data', (civBuf) => {
       this.emit('data', civBuf);
     });
-    this.civ.open()
-      .then(() => this.civ.startHandshake())
-      .catch((err) => this.emit('error', err));
+  }
+
+  _startCivStream(port, assignedPort = null) {
+    if (!this.civ) {
+      this.emit('error', makeRsba1Error('rsba1 CI-V stream was not prepared before stream start', 'RSBA1_CIV_NOT_PREPARED', this._handshakeDiagnostics()));
+      return;
+    }
+    if (this._civFallbackTimer) {
+      clearTimeout(this._civFallbackTimer);
+      this._civFallbackTimer = null;
+    }
+    this._assignedCivPort = assignedPort || port;
+    this._triedCivFallback = false;
+    this.civ.port = port;
+    this._handshakeStage = 'waiting-civ-IAmHere';
+    this.civ.startHandshake();
+    this._scheduleCivFallback();
+  }
+
+  _prepareAudioStream(host, displayHost, port, localAddress, log) {
+    if (this.audio) return;
+    this.audio = new AudioStream({
+      host,
+      displayHost,
+      port,
+      localAddress,
+      log,
+      rxCodec: this._target.rxAudioCodec,
+      rxSampleRate: this._target.rxAudioSampleRate,
+      enableTxAudio: this._target.enableTxAudio,
+      txCodec: this._target.txAudioCodec,
+      txSampleRate: this._target.txAudioSampleRate,
+      txAudioBufferMs: this._target.txAudioBufferMs,
+    });
+    this.audio.on('error', (e) => this.emit('error', e));
+    this.audio.on('ready', () => this.emit('audio-ready'));
+    this.audio.on('audio-frame', (frame) => this.emit('audio-frame', frame));
+  }
+
+  _startAudioStream(port) {
+    if (!this.audio) {
+      this.emit('error', makeRsba1Error('rsba1 audio stream was not prepared before stream start', 'RSBA1_AUDIO_NOT_PREPARED', this._handshakeDiagnostics()));
+      return;
+    }
+    this.audio.port = port;
+    this.audio.startHandshake();
+  }
+
+  restartAudioStream(reason = 'audio stall') {
+    if (!this.audio) return false;
+    const ok = this.audio.restartAudioFlow(reason);
+    if (ok) this.emit('log', `[rsba1/audio] restart requested: ${reason}`);
+    return ok;
   }
 
   disconnect() {
+    this._connectToken++;
     if (this._handshakeDeadline) {
       clearTimeout(this._handshakeDeadline);
       this._handshakeDeadline = null;
     }
+    if (this._civFallbackTimer) {
+      clearTimeout(this._civFallbackTimer);
+      this._civFallbackTimer = null;
+    }
+    if (this.audio)   { this.audio.close();   this.audio = null; }
     if (this.civ)     { this.civ.close();     this.civ = null; }
     if (this.control) { this.control.close(); this.control = null; }
     if (this._connected) {
       this._connected = false;
       this.emit('close');
     }
+    this._handshakeStage = 'idle';
+    this._assignedCivPort = null;
+    this._triedCivFallback = false;
+  }
+
+  _scheduleCivFallback() {
+    if (!this.civ || this._target.civPort || this._triedCivFallback) return;
+    const fallbackPort = (this._target.controlPort || 50001) + 1;
+    if (!fallbackPort || this.civ.port === fallbackPort) return;
+    this._civFallbackTimer = setTimeout(() => {
+      this._civFallbackTimer = null;
+      if (this._connected || !this.civ || this.civ.gotIAmHere || this._target.civPort || this._triedCivFallback) return;
+      this._triedCivFallback = true;
+      const originalPort = this.civ.port;
+      if (this.civ.aytTimer) {
+        clearInterval(this.civ.aytTimer);
+        this.civ.aytTimer = null;
+      }
+      this.civ.port = fallbackPort;
+      this.civ.aytCount = 0;
+      this.emit('log', `[rsba1/civ] no IAmHere on advertised port ${originalPort}; retrying fallback port ${fallbackPort}`);
+      this._handshakeStage = 'waiting-civ-IAmHere';
+      this.civ.startHandshake();
+    }, 3000);
+  }
+
+  _startHandshakeWatchdog(timeoutMs) {
+    if (this._handshakeDeadline) clearTimeout(this._handshakeDeadline);
+    this._handshakeDeadline = setTimeout(() => {
+      if (!this._connected) {
+        const details = this._handshakeDiagnostics();
+        const err = this._makeTimeoutError(details);
+        this.emit('error', err);
+        this.disconnect();
+      }
+    }, Math.max(100, Number(timeoutMs) || HANDSHAKE_TIMEOUT));
+  }
+
+  _handshakeDiagnostics() {
+    let stage = this._handshakeStage || 'unknown';
+    if (this.control && !this.control.connected) {
+      stage = this.control.gotIAmHere ? `control-${this.control.authStage || 'unknown'}` : 'waiting-control-IAmHere';
+    } else if (this.civ && !this.civ.connected) {
+      stage = this.civ.gotIAmHere ? 'waiting-civ-IAmReady' : 'waiting-civ-IAmHere';
+    }
+    return {
+      stage,
+      host: this._target ? this._target.host : null,
+      resolvedHost: this._target ? this._target.resolvedHost : null,
+      localAddress: this._target ? this._target.localAddress : null,
+      controlPort: this._target ? this._target.controlPort : null,
+      civPort: this.civ ? this.civ.port : (this._target ? this._target.civPort : null),
+      assignedCivPort: this._assignedCivPort,
+      triedCivFallback: this._triedCivFallback,
+      civLocalPort: this.civ ? this.civ.localPort : (this._target ? this._target.civLocalPort : null),
+      audioLocalPort: this.audio ? this.audio.localPort : (this._target ? this._target.audioLocalPort : null),
+      controlId: this.control ? this.control.myId : null,
+      civId: this.civ ? this.civ.myId : null,
+      audioId: this.audio ? this.audio.myId : null,
+      selectedRadio: this.control && this.control.radioInfo ? {
+        name: this.control.radioInfo.name,
+        civAddress: this.control.radioInfo.civAddress,
+        commoncap: this.control.radioInfo.commoncap,
+      } : null,
+      controlAuthMode: this.control ? this.control.authMode : (this._target ? this._target.controlAuthMode : null),
+      controlLastAuth: this.control && this.control.lastAuth ? { ...this.control.lastAuth } : null,
+      controlAuthRetryCount: this.control ? this.control.authRetryCount : 0,
+      controlAytCount: this.control ? this.control.aytCount : 0,
+      civAytCount: this.civ ? this.civ.aytCount : 0,
+      controlSendError: this.control ? this.control.lastSendError : null,
+      civSendError: this.civ ? this.civ.lastSendError : null,
+    };
+  }
+
+  _makeTimeoutError(details) {
+    const target = `${details.host || 'radio'}:${details.controlPort || 50001}`;
+    const resolved = details.resolvedHost && details.resolvedHost !== details.host
+      ? ` (resolved to ${details.resolvedHost})`
+      : '';
+    if (details.stage === 'waiting-control-IAmHere') {
+      return makeRsba1Error(
+        `rsba1 handshake timed out before IAmHere: sent ${details.controlAytCount} AreYouThere UDP packet(s) to ${target}${resolved}; no reply from the radio. This is before username/password validation.`,
+        'RSBA1_NO_IAMHERE',
+        details
+      );
+    }
+    if (details.stage === 'waiting-civ-IAmHere') {
+      return makeRsba1Error(
+        `rsba1 CI-V stream timed out before IAmHere: control login succeeded, but the radio did not answer ${details.civAytCount} CI-V AreYouThere UDP packet(s) on port ${details.civPort}.`,
+        'RSBA1_NO_CIV_IAMHERE',
+        details
+      );
+    }
+    if (String(details.stage || '').startsWith('control-')) {
+      const last = details.controlLastAuth || {};
+      const id = (value) => Number.isFinite(value) ? `0x${(value >>> 0).toString(16)}` : 'n/a';
+      const tok = Number.isFinite(last.tokRequest) ? `0x${(last.tokRequest & 0xffff).toString(16)}` : 'n/a';
+      const authDetails = last.label
+        ? ` Last auth packet: ${last.label} mode=${last.mode || details.controlAuthMode || 'unknown'} seq=${last.seq ?? 'n/a'} innerSeq=${last.innerSeq ?? 'n/a'} myId=${id(last.myId)} remoteId=${id(last.remoteId)} tokReq=${tok} retries=${last.retryCount ?? details.controlAuthRetryCount ?? 0}.`
+        : '';
+      return makeRsba1Error(
+        `rsba1 handshake timed out at stage ${details.stage || 'unknown'} for ${target}${resolved}.${authDetails}`,
+        'RSBA1_CONTROL_AUTH_TIMEOUT',
+        details
+      );
+    }
+    return makeRsba1Error(
+      `rsba1 handshake timed out at stage ${details.stage || 'unknown'} for ${target}${resolved}.`,
+      'RSBA1_HANDSHAKE_TIMEOUT',
+      details
+    );
   }
 
   write(buf) {
@@ -659,9 +2338,27 @@ class RsBa1Transport extends EventEmitter {
     return true;
   }
 
+  sendTxAudio(samples, offsetMs = 0, inputSampleRate = 12000) {
+    if (!this.audio) return Promise.reject(new Error('RS-BA1 audio stream is not open'));
+    return this.audio.sendTxAudio(samples, offsetMs, inputSampleRate);
+  }
+
+  cancelTx() {
+    if (this.audio) this.audio.cancelTx();
+  }
+
   // SerialTransport-compatible no-ops — RS-BA1 has no DTR/RTS/baud.
   setPin(_pins, cb) { if (cb) cb(null); }
   set(_pins, cb)    { if (cb) cb(null); }
 }
 
-module.exports = { RsBa1Transport, passcodeBytes, PASSCODE_TABLE };
+module.exports = {
+  RsBa1Transport,
+  passcodeBytes,
+  PASSCODE_TABLE,
+  AUDIO_CODEC_LPCM16_MONO,
+  AUDIO_CODEC_LPCM16_STEREO,
+  resampleMonoFloat32,
+  streamIdFromLocalAddress,
+  selectLocalAddressForTarget,
+};

--- a/main.js
+++ b/main.js
@@ -24,6 +24,19 @@ function logStartupStage(name) {
 const { app, BrowserWindow, ipcMain, Menu, dialog, Notification, screen, nativeImage, clipboard } = require('electron');
 const path = require('path');
 const fs = require('fs');
+const PACKAGE_VERSION = require('./package.json').version;
+function getAppDisplayVersion() {
+  try {
+    const localBuild = require('./local-build.json');
+    const build = Number(localBuild && localBuild.build);
+    if (localBuild && localBuild.baseVersion === PACKAGE_VERSION && Number.isInteger(build) && build > 0) {
+      return `${PACKAGE_VERSION}.${build}`;
+    }
+  } catch {
+    // Release builds do not need a local suffix.
+  }
+  return PACKAGE_VERSION;
+}
 // `app.name` defaults to package.json's `name` field, which is the
 // lowercase "potacat" used as the npm package name. Electron's native
 // confirm() / alert() dialogs put app.name in their title bar, so without
@@ -321,8 +334,6 @@ const GLOBAL_KEYS = new Set([
   'profiles',          // (reserved — currently unused but reserved against name collision)
   'rigs',              // rig hardware definitions
   'activeRigId',       // last-selected rig (global default)
-  'pairedDevices',     // ECHOCAT paired-device tokens
-  'cloudTunnelToken',  // CF Tunnel credential (machine-scoped)
   'firstRun',          // first-time-launch flag
   'piAccess',          // easter egg unlock
   'lightMode',         // theme
@@ -335,13 +346,70 @@ const GLOBAL_KEYS = new Set([
   'echocatPort',       // ECHOCAT server port
   'echocatToken',      // ECHOCAT legacy single shared token (machine)
   'enableEchoCat',     // ECHOCAT server enable (machine-level)
+  'cloudDeviceId',     // stable machine UUID for cloud device registration
+                       // (must be global so both operators' phones find the same shack)
 ]);
+
+const CLOUD_TUNNEL_CONFIG_FILENAME = 'cloud-tunnel.json';
 
 function profileDir(callsign) {
   return path.join(PROFILES_DIR, String(callsign || '').toUpperCase());
 }
 function profileSettingsPath(callsign) {
   return path.join(profileDir(callsign), 'settings.json');
+}
+function profileCloudTunnelPath(callsign) {
+  const call = String(callsign || '').toUpperCase().trim();
+  return call
+    ? path.join(profileDir(call), CLOUD_TUNNEL_CONFIG_FILENAME)
+    : path.join(app.getPath('userData'), CLOUD_TUNNEL_CONFIG_FILENAME);
+}
+
+function inferCallsignFromCloudHost(host) {
+  const firstLabel = String(host || '').trim().split(':')[0].split('.')[0].toUpperCase();
+  return /^[A-Z0-9/]{3,12}$/.test(firstLabel) ? firstLabel : '';
+}
+
+function migrateLegacyCloudTunnelConfig(settingsObj) {
+  const legacyPath = path.join(app.getPath('userData'), CLOUD_TUNNEL_CONFIG_FILENAME);
+  if (!fs.existsSync(legacyPath)) return;
+  let cfg = null;
+  try {
+    cfg = JSON.parse(fs.readFileSync(legacyPath, 'utf8'));
+  } catch (err) {
+    console.log('[cloud-tunnel] legacy config parse failed; leaving shared file in place: ' + (err.message || err));
+    return;
+  }
+
+  const activeCall = String((settingsObj && (settingsObj.activeProfile || settingsObj.myCallsign)) || '').toUpperCase().trim();
+  const hostCall = inferCallsignFromCloudHost(cfg.cloudHost);
+  let ownerCall = '';
+  if (hostCall && fs.existsSync(profileDir(hostCall))) ownerCall = hostCall;
+  else if (activeCall && (!hostCall || hostCall === activeCall)) ownerCall = activeCall;
+
+  if (!ownerCall) {
+    console.log('[cloud-tunnel] legacy shared tunnel has no matching operator profile; leaving it inactive at ' + legacyPath);
+    return;
+  }
+
+  const destPath = profileCloudTunnelPath(ownerCall);
+  try {
+    fs.mkdirSync(path.dirname(destPath), { recursive: true });
+    if (!fs.existsSync(destPath)) {
+      fs.copyFileSync(legacyPath, destPath);
+      try { fs.chmodSync(destPath, 0o600); } catch {}
+      console.log('[cloud-tunnel] migrated shared tunnel config to profiles/' + ownerCall + '/' + CLOUD_TUNNEL_CONFIG_FILENAME);
+    }
+    const archivedPath = legacyPath + '.legacy';
+    try {
+      if (!fs.existsSync(archivedPath)) fs.renameSync(legacyPath, archivedPath);
+      else fs.unlinkSync(legacyPath);
+    } catch (err) {
+      console.log('[cloud-tunnel] could not archive legacy shared tunnel config: ' + (err.message || err));
+    }
+  } catch (err) {
+    console.log('[cloud-tunnel] legacy config migration failed: ' + (err.message || err));
+  }
 }
 
 function _readJsonSafe(p, fallback) {
@@ -357,7 +425,7 @@ function loadSettings() {
   const global = _readJsonSafe(SETTINGS_PATH, null);
   if (!global) {
     // Truly fresh install: return defaults, no profile yet.
-    return { grid: 'FN20jb', catTarget: null, enablePota: true, enableSota: false, firstRun: true, watchlist: 'K3SBP' };
+    return { grid: '', catTarget: null, enablePota: true, enableSota: false, firstRun: true, watchlist: '' };
   }
   // Migration path: legacy settings.json (no activeProfile) gets migrated
   // when it has a myCallsign. We do this lazily on first save rather than
@@ -397,6 +465,12 @@ function saveSettings(s) {
   const { global, profile } = _splitSettings(s);
   _writeJsonAtomic(SETTINGS_PATH, global);
   _writeJsonAtomic(profileSettingsPath(global.activeProfile), profile);
+}
+
+function setActiveProfilePointer(callsign) {
+  const global = _readJsonSafe(SETTINGS_PATH, {});
+  global.activeProfile = String(callsign || '').toUpperCase();
+  _writeJsonAtomic(SETTINGS_PATH, global);
 }
 
 // Profile management — used by IPC handlers below to back the
@@ -443,19 +517,64 @@ function switchProfile(callsign) {
   const call = String(callsign || '').toUpperCase().trim();
   if (!call) return { ok: false, error: 'No callsign specified.' };
   if (!fs.existsSync(profileDir(call))) return { ok: false, error: 'Operator ' + call + ' does not exist.' };
+  // No-op if already active — prevents accidental restart from a stale UI state
+  if (settings && call === String(settings.activeProfile || '').toUpperCase()) {
+    return { ok: true, callsign: call, previousCallsign: call, restartRequired: false, alreadyActive: true };
+  }
   // Save current operator's state (so any unsaved field changes persist),
   // flip the activeProfile pointer in the global file, then we relaunch.
   // Live-reload (re-init cluster/RBN/PSKR/POTA sync/Cloud auth/etc.
   // against the new operator's settings) is a follow-up — too many cached
   // subsystems to chase down in one PR. Restart is one click and
   // guarantees correctness.
+  let currentProfile = '';
   try {
-    settings.activeProfile = call;
+    currentProfile = settings.activeProfile;
     saveSettings(settings);
+    setActiveProfilePointer(call);
+    settings.activeProfile = call;
+    if (currentProfile && currentProfile !== call) {
+      console.log('[multi-op] switched activeProfile ' + currentProfile + ' -> ' + call);
+    }
   } catch (err) {
     return { ok: false, error: 'Failed to save before switching: ' + err.message };
   }
-  return { ok: true, callsign: call, restartRequired: true };
+  return { ok: true, callsign: call, previousCallsign: currentProfile || '', restartRequired: true };
+}
+
+let _profileSwitchRelaunchPending = false;
+async function prepareProfileSwitchRelaunch(fromCall, toCall) {
+  if (_profileSwitchRelaunchPending) return;
+  _profileSwitchRelaunchPending = true;
+  const label = `[multi-op] preparing clean profile switch ${fromCall || '?'} -> ${toCall || '?'}`;
+  try { appendIcomNetworkDiagnostic(label); } catch {}
+  try { sendCatLog(label); } catch {}
+
+  clearIcomNetworkConnectRetry(true);
+  try { handleRemotePtt(false, { source: 'profile-switch' }); } catch {}
+  try { if (_icomNetworkTransport) _icomNetworkTransport.cancelTx(); } catch {}
+  try { await restoreIcomNetworkDataMod('operator switch'); } catch (err) {
+    try { appendIcomNetworkDiagnostic(`[multi-op] DATA MOD restore before switch failed: ${err.message || err}`); } catch {}
+  }
+  try { stopIcomNetworkRxWatchdog(); } catch {}
+  try { resetIcomNetworkRxPacer('profile switch'); } catch {}
+  try {
+    if (cat) {
+      cat.removeAllListeners();
+      cat.disconnect();
+      cat = null;
+    }
+  } catch (err) {
+    try { appendIcomNetworkDiagnostic(`[multi-op] CAT disconnect before switch failed: ${err.message || err}`); } catch {}
+  }
+  _icomNetworkTransport = null;
+  try { sendCatStatus({ connected: false, target: null }); } catch {}
+
+  // RS-BA1 disconnect packets are sent over UDP just before socket close.
+  // Give them time to leave this process and give the radio a short release
+  // window before the relaunched instance starts its startup-delay reconnect.
+  await new Promise(r => setTimeout(r, ICOM_NETWORK_PROFILE_SWITCH_RELEASE_DELAY_MS));
+  try { appendIcomNetworkDiagnostic(`[multi-op] clean profile switch release complete after ${ICOM_NETWORK_PROFILE_SWITCH_RELEASE_DELAY_MS}ms`); } catch {}
 }
 
 function archiveProfile(callsign) {
@@ -475,6 +594,31 @@ function archiveProfile(callsign) {
   } catch (err) {
     return { ok: false, error: err.message };
   }
+}
+
+// Load paired devices from ALL operator profiles into one merged list.
+// Called at remoteServer startup so every phone can authenticate regardless
+// of which profile is currently active. pairedDevices remains per-profile
+// on disk; this is an in-memory union for auth purposes only.
+// Devices that pre-date the profileCallsign field get it back-filled from
+// the profile directory they lived in, so existing pairings keep working.
+function loadAllProfilePairedDevices() {
+  const profiles = listProfiles();
+  const merged = [];
+  const seen = new Set();
+  for (const call of profiles) {
+    try {
+      const pSettings = _readJsonSafe(profileSettingsPath(call), {});
+      const devices = Array.isArray(pSettings.pairedDevices) ? pSettings.pairedDevices : [];
+      for (const dev of devices) {
+        if (!dev || !dev.id || seen.has(dev.id)) continue;
+        seen.add(dev.id);
+        // Back-fill profileCallsign for devices paired before this feature
+        merged.push(dev.profileCallsign ? dev : { ...dev, profileCallsign: call });
+      }
+    } catch { /* corrupt profile dir — skip */ }
+  }
+  return merged;
 }
 
 let settings = null;
@@ -531,6 +675,7 @@ const _audioBus = new Map(); // wcId+':'+channel -> { sent, acked, dropped, last
 const AUDIO_MAX_BACKLOG = 40; // frames; ~210 ms at 190 fps — survives a
                               // GC pause without garbling, well below
                               // the multi-second backlog that leaks.
+const _jtcatIpAudioReady = new Set();
 
 function audioSafeSend(wc, channel, payload) {
   if (!wc || wc.isDestroyed()) return;
@@ -548,6 +693,9 @@ function audioSafeSend(wc, channel, payload) {
         // Single CAT log line every 10 s when a consumer is sustaining
         // a backlog — enough signal to diagnose, no flood.
         sendCatLog(`[Audio] Backpressure on ${channel}: ${info.dropped} frames dropped (renderer not keeping up)`);
+        if (channel === 'jtcat-vita49-audio' || channel === 'sstv-vita49-audio' || channel === 'smartsdr-audio-frame') {
+          appendDiagnosticLog('rsba1-rx-diagnostics.log', `BACKPRESSURE channel=${channel} wc=${wc.id} dropped=${info.dropped} backlog=${info.sent - info.acked}`);
+        }
       } catch {}
       info.dropped = 0;
       info.lastDropLogMs = now;
@@ -567,13 +715,34 @@ ipcMain.on('audio-ack', (e, msg) => {
   if (info) info.acked += count;
 });
 
+ipcMain.on('jtcat-ip-audio-ready', (e, msg) => {
+  const ready = !!(msg && msg.ready);
+  const wcId = e.sender && e.sender.id;
+  if (!wcId) return;
+  if (ready) {
+    _jtcatIpAudioReady.add(wcId);
+  } else {
+    _jtcatIpAudioReady.delete(wcId);
+  }
+  try {
+    appendDiagnosticLog('rsba1-rx-diagnostics.log', `JTCAT-IP-AUDIO-READY wc=${wcId} ready=${ready ? 1 : 0}`);
+  } catch {}
+});
+
+function isJtcatIpAudioReady(windowRef) {
+  return !!(windowRef && !windowRef.isDestroyed() && windowRef.webContents && _jtcatIpAudioReady.has(windowRef.webContents.id));
+}
+
 // Periodic sweep — drop entries whose webContents was destroyed so the
 // map doesn't grow unboundedly across popout open/close cycles.
 setInterval(() => {
   for (const [key, info] of _audioBus) {
     const wcId = parseInt(key.split(':')[0], 10);
     const wc = require('electron').webContents.fromId(wcId);
-    if (!wc || wc.isDestroyed()) _audioBus.delete(key);
+    if (!wc || wc.isDestroyed()) {
+      _audioBus.delete(key);
+      _jtcatIpAudioReady.delete(wcId);
+    }
   }
 }, 30_000);
 let _sstvLastActivityMs = 0; // last VIS/image timestamp — for heartbeat log
@@ -581,13 +750,57 @@ let _sstvHeartbeatTimer = null;
 let sstvManager = null;      // SSTV multi-slice manager
 let openSstvPopout = null;   // function — assigned in second whenReady block
 let startSstv = null;        // function — assigned in second whenReady block (same reason)
-const SSTV_GALLERY_DIR = path.join(app.getPath('userData'), 'sstv-gallery');
+function defaultSstvGalleryDir() {
+  return path.join(app.getPath('pictures'), 'POTACAT', 'SSTV-RX');
+}
+function legacySstvGalleryDir() {
+  return path.join(app.getPath('userData'), 'sstv-gallery');
+}
+function getSstvGalleryDir() {
+  return (settings && settings.sstvDecodedImagesPath) || defaultSstvGalleryDir();
+}
+let _sstvLegacyGalleryMigrated = false;
+function migrateLegacySstvGalleryIfNeeded(dir) {
+  if (_sstvLegacyGalleryMigrated) return;
+  _sstvLegacyGalleryMigrated = true;
+  if (settings && settings.sstvDecodedImagesPath) return;
+  const oldDir = legacySstvGalleryDir();
+  if (oldDir === dir || !fs.existsSync(oldDir)) return;
+  try {
+    const files = fs.readdirSync(oldDir).filter(f => /\.(png|json)$/i.test(f));
+    for (const f of files) {
+      const src = path.join(oldDir, f);
+      const dest = path.join(dir, f);
+      if (!fs.existsSync(dest)) fs.copyFileSync(src, dest);
+    }
+    if (files.length) sendCatLog(`[SSTV] Copied ${files.length} legacy gallery file(s) to ${dir}`);
+  } catch (err) {
+    console.error('[SSTV] Legacy gallery migration error:', err.message);
+  }
+}
 function ensureSstvGalleryDir() {
-  if (!fs.existsSync(SSTV_GALLERY_DIR)) fs.mkdirSync(SSTV_GALLERY_DIR, { recursive: true });
+  const dir = getSstvGalleryDir();
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  migrateLegacySstvGalleryIfNeeded(dir);
+  return dir;
 }
 let jtcatMapPopoutWin = null; // pop-out JTCAT map window
 let popoutJtcatQso = null;   // QSO state for popout (like remoteJtcatQso for ECHOCAT)
 let cat = null;
+let _icomNetworkTransport = null;
+let _icomNetworkDataModRestore = null;
+let _icomNetworkDataModSession = 0;
+const DEFAULT_JTCAT_TX_PWR_PCT = 100;
+const DEFAULT_JTCAT_TX_GAIN = (DEFAULT_JTCAT_TX_PWR_PCT / 100) * (DEFAULT_JTCAT_TX_PWR_PCT / 100);
+const DIRECT_TX_PEAK_LIMIT = 0.95;
+const ICOM_NETWORK_TX_SAMPLE_RATE = 48000;
+const ICOM_NETWORK_TX_BUFFER_MS = 200; // 150→200ms: raises paceLeadMs 100→150ms, improves Wi-Fi TX resilience
+const ICOM_NETWORK_TUNE_START_DELAY_MS = 200;
+const ICOM_NETWORK_TUNE_PEAK = 0.45;
+const DEFAULT_ICOM_NETWORK_TX_GAIN = 0.72;
+const ICOM_NETWORK_TX_AUDIO_ENABLED = true;
+const ICOM_NETWORK_PROFILE_SWITCH_RELEASE_DELAY_MS = 1200;
+let _jtcatDirectTxGainLevel = DEFAULT_JTCAT_TX_GAIN;
 let spotTimer = null;
 let solarTimer = null;
 let rigctldProc = null;
@@ -1332,6 +1545,348 @@ function sendCatLog(msg) {
   if (win && !win.isDestroyed()) win.webContents.send('cat-log', line);
 }
 
+function appendDiagnosticLog(fileName, msg) {
+  try {
+    const dir = app.getPath('userData');
+    const file = path.join(dir, fileName);
+    const maxBytes = 2 * 1024 * 1024;
+    if (fs.existsSync(file) && fs.statSync(file).size > maxBytes) {
+      const rotated = file + '.old';
+      try { if (fs.existsSync(rotated)) fs.unlinkSync(rotated); } catch {}
+      try { fs.renameSync(file, rotated); } catch {}
+    }
+    fs.appendFileSync(file, `[${new Date().toISOString()}] ${msg}\n`);
+  } catch (err) {
+    try { console.log(`[diagnostic-log] ${fileName}: ${err.message || err}`); } catch {}
+  }
+}
+
+function appendIcomNetworkDiagnostic(msg) {
+  appendDiagnosticLog('rsba1-rx-diagnostics.log', msg);
+}
+
+function shouldKeepIcomNetworkTransportLog(msg) {
+  const line = String(msg || '');
+  if (!line) return false;
+  if (/length mismatch: header=0 actual=21/i.test(line)) return false;
+  if (/<- control type 0x0\b/i.test(line)) return false;
+  if (/retransmit request for unknown seq/i.test(line)) return false;
+  if (/^\[rsba1\/(?:civ|audio)\] send skipped: invalid remote UDP port 0/i.test(line)) return false;
+  if (/^\[rsba1\/civ\] (?:<-|->) CI-V /i.test(line)) return false;
+
+  const ayt = line.match(/-> AreYouThere #(\d+)/i);
+  if (ayt) {
+    const n = Number(ayt[1]);
+    return n <= 3 || n % 10 === 0;
+  }
+
+  return true;
+}
+
+function shouldShowIcomNetworkTransportLogInCat(msg) {
+  const line = String(msg || '');
+  if (!shouldKeepIcomNetworkTransportLog(line)) return false;
+  if (/-> AreYouThere #/i.test(line)) return false;
+  if (/bound on /i.test(line)) return false;
+  return true;
+}
+
+function clampNumber(value, min, max, fallback) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.max(min, Math.min(max, n));
+}
+
+function setJtcatDirectTxGainLevel(level) {
+  _jtcatDirectTxGainLevel = clampNumber(level, 0, 1, _jtcatDirectTxGainLevel);
+  return _jtcatDirectTxGainLevel;
+}
+
+function getIcomNetworkTxGain() {
+  const target = settings && settings.catTarget && settings.catTarget.type === 'icom-network'
+    ? settings.catTarget
+    : null;
+  return clampNumber(target && target.networkTxGain, 0, 1.5, DEFAULT_ICOM_NETWORK_TX_GAIN);
+}
+
+function getIcomNetworkTunePeak() {
+  return clampNumber(ICOM_NETWORK_TUNE_PEAK * (getIcomNetworkTxGain() / DEFAULT_ICOM_NETWORK_TX_GAIN), 0.01, 1, ICOM_NETWORK_TUNE_PEAK);
+}
+
+function coerceTxFloat32(samples) {
+  if (samples instanceof Float32Array) return samples;
+  const length = samples && typeof samples.length === 'number' ? samples.length : 0;
+  const out = new Float32Array(length);
+  for (let i = 0; i < length; i++) {
+    const v = Number(samples[i]);
+    out[i] = Number.isFinite(v) ? v : 0;
+  }
+  return out;
+}
+
+function conditionDirectTxAudio(samples, gainLevel, peakLimit = DIRECT_TX_PEAK_LIMIT) {
+  const src = coerceTxFloat32(samples);
+  const gain = clampNumber(gainLevel, 0, 1, 1);
+  const limit = clampNumber(peakLimit, 0.01, 1, DIRECT_TX_PEAK_LIMIT);
+  const out = new Float32Array(src.length);
+  let inputPeak = 0;
+  let outputPeak = 0;
+  let inputSumSq = 0;
+  let outputSumSq = 0;
+  let limited = 0;
+
+  for (let i = 0; i < src.length; i++) {
+    const input = Number.isFinite(src[i]) ? src[i] : 0;
+    const absIn = Math.abs(input);
+    if (absIn > inputPeak) inputPeak = absIn;
+    inputSumSq += input * input;
+
+    let output = input * gain;
+    if (output > limit) {
+      output = limit;
+      limited++;
+    } else if (output < -limit) {
+      output = -limit;
+      limited++;
+    }
+
+    out[i] = output;
+    const absOut = Math.abs(output);
+    if (absOut > outputPeak) outputPeak = absOut;
+    outputSumSq += output * output;
+  }
+
+  const len = src.length || 1;
+  return {
+    samples: out,
+    gain,
+    peakLimit: limit,
+    inputPeak,
+    outputPeak,
+    inputRms: Math.sqrt(inputSumSq / len),
+    outputRms: Math.sqrt(outputSumSq / len),
+    limited,
+  };
+}
+
+function formatDirectTxAudioStats(shaped) {
+  return `gain=${shaped.gain.toFixed(3)} peak ${shaped.inputPeak.toFixed(3)}->${shaped.outputPeak.toFixed(3)} rms ${shaped.inputRms.toFixed(3)}->${shaped.outputRms.toFixed(3)} limited=${shaped.limited}`;
+}
+
+function analyzeDigitalTxEnvelope(samples, sampleRate = 12000, mode = 'FT8') {
+  const src = coerceTxFloat32(samples);
+  const rate = clampNumber(sampleRate, 1, 192000, 12000);
+  let peak = 0;
+  let sumSq = 0;
+  let maxDelta = 0;
+  let zeroRun = 0;
+  let maxZeroRun = 0;
+  for (let i = 0; i < src.length; i++) {
+    const v = Number.isFinite(src[i]) ? src[i] : 0;
+    const a = Math.abs(v);
+    if (a > peak) peak = a;
+    sumSq += v * v;
+    if (i > 0) {
+      const d = Math.abs(v - src[i - 1]);
+      if (d > maxDelta) maxDelta = d;
+    }
+    if (a < 1e-6) {
+      zeroRun++;
+      if (zeroRun > maxZeroRun) maxZeroRun = zeroRun;
+    } else {
+      zeroRun = 0;
+    }
+  }
+  const expected = mode === 'FT4' ? 60480 : mode === 'FT2' ? 30240 : 151680;
+  const len = src.length || 1;
+  return {
+    mode,
+    sampleRate: rate,
+    samples: src.length,
+    durationSec: src.length / rate,
+    expectedSamples: expected,
+    sampleDelta: src.length - expected,
+    peak,
+    rms: Math.sqrt(sumSq / len),
+    maxDelta,
+    maxZeroRunMs: maxZeroRun / rate * 1000,
+  };
+}
+
+function formatDigitalTxEnvelopeStats(stats) {
+  return `${stats.mode} envelope=${stats.samples}/${stats.expectedSamples} samples (${stats.durationSec.toFixed(3)}s, delta=${stats.sampleDelta}) peak=${stats.peak.toFixed(3)} rms=${stats.rms.toFixed(3)} maxDelta=${stats.maxDelta.toFixed(3)} zeroRunMax=${stats.maxZeroRunMs.toFixed(1)}ms`;
+}
+
+function makeSineToneSamples(freqHz, durationSec, sampleRate = 12000, peak = 0.5) {
+  const rate = clampNumber(sampleRate, 8000, 192000, 12000);
+  const total = Math.max(1, Math.round(clampNumber(durationSec, 0.1, 300, 1) * rate));
+  const freq = clampNumber(freqHz, 20, rate / 2 - 1, 1500);
+  const amp = clampNumber(peak, 0, 1, 0.5);
+  const out = new Float32Array(total);
+  const step = 2 * Math.PI * freq / rate;
+  for (let i = 0; i < total; i++) out[i] = Math.sin(i * step) * amp;
+  applyRaisedCosineFade(out, rate, 15);
+  return out;
+}
+
+function applyRaisedCosineFade(samples, sampleRate = 48000, fadeMs = 10) {
+  if (!samples || !samples.length) return samples;
+  const rate = clampNumber(sampleRate, 8000, 192000, 48000);
+  const fadeSamples = Math.min(Math.floor(samples.length / 2), Math.max(1, Math.round(rate * fadeMs / 1000)));
+  for (let i = 0; i < fadeSamples; i++) {
+    const gain = 0.5 - 0.5 * Math.cos(Math.PI * i / fadeSamples);
+    samples[i] *= gain;
+    samples[samples.length - 1 - i] *= gain;
+  }
+  return samples;
+}
+
+const ICOM_NETWORK_DATA_MOD_SPECS = [
+  {
+    models: ['IC-7610'],
+    civAddrs: [0x98],
+    settingId: 0x0092,
+    label: 'DATA1 MOD',
+    networkLabel: 'LAN',
+    networkValue: 0x05,
+    values: { 0x00: 'MIC', 0x01: 'ACC', 0x02: 'MIC+ACC', 0x03: 'USB', 0x04: 'MIC+USB', 0x05: 'LAN' },
+  },
+  {
+    models: ['IC-9700'],
+    civAddrs: [0xA2],
+    settingId: 0x0116,
+    label: 'DATA MOD',
+    networkLabel: 'LAN',
+    networkValue: 0x05,
+    values: { 0x00: 'MIC', 0x01: 'ACC', 0x02: 'MIC+ACC', 0x03: 'USB', 0x04: 'MIC+USB', 0x05: 'LAN' },
+  },
+  {
+    models: ['IC-705'],
+    civAddrs: [0xA4],
+    settingId: 0x0119,
+    label: 'DATA MOD',
+    networkLabel: 'WLAN',
+    networkValue: 0x03,
+    values: { 0x00: 'MIC', 0x01: 'USB', 0x02: 'MIC+USB', 0x03: 'WLAN' },
+  },
+];
+
+function getActiveRigModelName() {
+  const activeRig = (settings.rigs || []).find(r => r.id === settings.activeRigId);
+  return activeRig?.model || '';
+}
+
+function getIcomNetworkDataModSpec(target, rigModel) {
+  const modelName = String(getActiveRigModelName() || target?.model || target?.name || '').toUpperCase();
+  const civAddr = Number(target?.civAddr ?? rigModel?.civAddr);
+  return ICOM_NETWORK_DATA_MOD_SPECS.find((spec) => {
+    if (modelName && spec.models.some((m) => modelName === m.toUpperCase())) return true;
+    return Number.isFinite(civAddr) && spec.civAddrs.includes(civAddr);
+  }) || null;
+}
+
+function formatIcomDataModValue(spec, value) {
+  const n = Number(value);
+  const label = spec && spec.values ? spec.values[n] : null;
+  return label ? `${label} (0x${n.toString(16).toUpperCase().padStart(2, '0')})` : `0x${n.toString(16).toUpperCase().padStart(2, '0')}`;
+}
+
+function logIcomNetworkAudio(msg) {
+  sendCatLog(msg);
+  appendIcomNetworkDiagnostic(msg);
+}
+
+function waitForIcomDataMod(controller, settingId, timeoutMs = 1500) {
+  return new Promise((resolve) => {
+    if (!controller || typeof controller.getDataMod !== 'function') {
+      resolve(null);
+      return;
+    }
+    let done = false;
+    let timer = null;
+    const cleanup = () => {
+      if (done) return;
+      done = true;
+      if (timer) clearTimeout(timer);
+      controller.removeListener('data-mod', onDataMod);
+    };
+    const onDataMod = (data) => {
+      if (!data || data.settingId !== settingId) return;
+      cleanup();
+      resolve(data);
+    };
+    controller.on('data-mod', onDataMod);
+    timer = setTimeout(() => {
+      cleanup();
+      resolve(null);
+    }, timeoutMs);
+    try {
+      controller.getDataMod(settingId);
+    } catch {
+      cleanup();
+      resolve(null);
+    }
+  });
+}
+
+async function prepareIcomNetworkDataMod(controller, target, rigModel, sessionId) {
+  if (!controller || !controller.connected) return;
+  if (!target || target.type !== 'icom-network') return;
+  if (settings.audioSource !== 'icom-network') return;
+  const spec = getIcomNetworkDataModSpec(target, rigModel);
+  if (!spec) {
+    logIcomNetworkAudio('[Icom-Network-Audio] DATA MOD auto-LAN is not configured for this Icom model; leaving radio MOD input unchanged.');
+    return;
+  }
+  if (typeof controller.getDataMod !== 'function' || typeof controller.setDataMod !== 'function') {
+    logIcomNetworkAudio(`[Icom-Network-Audio] ${spec.label} auto-LAN skipped: CI-V settings commands are unavailable.`);
+    return;
+  }
+
+  const data = await waitForIcomDataMod(controller, spec.settingId, 1800);
+  if (sessionId !== _icomNetworkDataModSession || cat !== controller || !controller.connected) return;
+  if (!data) {
+    logIcomNetworkAudio(`[Icom-Network-Audio] Could not read ${spec.label}; leaving radio MOD input unchanged so there is no unsafe restore guess.`);
+    return;
+  }
+
+  const currentValue = data.value;
+  if (currentValue === spec.networkValue) {
+    logIcomNetworkAudio(`[Icom-Network-Audio] ${spec.label} is already ${formatIcomDataModValue(spec, currentValue)} for network TX audio.`);
+    return;
+  }
+
+  _icomNetworkDataModRestore = {
+    controller,
+    sessionId,
+    spec,
+    previousValue: currentValue,
+    target,
+  };
+  logIcomNetworkAudio(`[Icom-Network-Audio] ${spec.label} is ${formatIcomDataModValue(spec, currentValue)}; setting to ${formatIcomDataModValue(spec, spec.networkValue)} for RS-BA1 TX audio. It will be restored on disconnect.`);
+  controller.setDataMod(spec.settingId, spec.networkValue);
+}
+
+async function restoreIcomNetworkDataMod(reason = 'disconnect') {
+  const state = _icomNetworkDataModRestore;
+  if (!state) return false;
+  _icomNetworkDataModRestore = null;
+  const { controller, spec, previousValue } = state;
+  if (!controller || !controller.connected || typeof controller.setDataMod !== 'function') {
+    sendCatLog(`[Icom-Network-Audio] Could not restore ${spec.label} to ${formatIcomDataModValue(spec, previousValue)} (${reason}) because the Icom Network session is already closed.`);
+    return false;
+  }
+  try {
+    controller.setDataMod(spec.settingId, previousValue);
+    sendCatLog(`[Icom-Network-Audio] Restored ${spec.label} to ${formatIcomDataModValue(spec, previousValue)} (${reason}).`);
+    await new Promise(r => setTimeout(r, 150));
+    return true;
+  } catch (err) {
+    sendCatLog(`[Icom-Network-Audio] Failed to restore ${spec.label}: ${err.message || err}`);
+    return false;
+  }
+}
+
 // PstRotator UDP rotor control
 const dgram = require('dgram');
 let rotorSocket = null;
@@ -1656,16 +2211,129 @@ function tearDownRemoteClient() {
 }
 
 let _connectCatPending = false;
+let _icomNetworkConnectRetryTimer = null;
+let _icomNetworkConnectRetryAttempts = 0;
+let _icomNetworkConnectRetryKey = '';
+let _icomNetworkConnectRetryActive = false;
+const ICOM_NETWORK_STARTUP_CONNECT_DELAY_MS = 3500;
+const ICOM_NETWORK_CONNECT_RETRY_DELAYS_MS = [3000, 6000, 12000, 24000, 45000, 75000];
+
+function icomNetworkTargetKey(target = settings && settings.catTarget) {
+  if (!target || target.type !== 'icom-network') return '';
+  return [
+    String(target.host || '').trim(),
+    Number(target.controlPort || target.port || 50001) || 50001,
+    Number(target.civPort || 0) || 0,
+    String(target.username || ''),
+    settings && settings.audioSource === 'icom-network' ? 'audio' : 'cat',
+  ].join('|');
+}
+
+function clearIcomNetworkConnectRetry(resetAttempts = false) {
+  if (_icomNetworkConnectRetryTimer) {
+    clearTimeout(_icomNetworkConnectRetryTimer);
+    _icomNetworkConnectRetryTimer = null;
+  }
+  if (resetAttempts) {
+    _icomNetworkConnectRetryAttempts = 0;
+    _icomNetworkConnectRetryKey = '';
+  }
+}
+
+function isRetriableIcomNetworkConnectError(err) {
+  const code = err && err.code;
+  if (code === 'RSBA1_AUTH_FAILED' || code === 'RSBA1_DNS_FAILED') return false;
+  if (code && [
+    'RSBA1_NO_IAMHERE',
+    'RSBA1_NO_CIV_IAMHERE',
+    'RSBA1_CONTROL_AUTH_TIMEOUT',
+    'RSBA1_HANDSHAKE_TIMEOUT',
+    'RSBA1_LOCAL_PORT_FAILED',
+    'RSBA1_STATUS_REJECTED',
+  ].includes(code)) return true;
+  const message = String((err && err.message) || err || '');
+  return /EHOSTUNREACH|ENETUNREACH|timed out|no reply from the radio|before IAmHere|rejected stream request|status error/i.test(message);
+}
+
+function scheduleIcomNetworkConnectRetry(err, targetKey = icomNetworkTargetKey()) {
+  const target = settings && settings.catTarget;
+  if (!target || target.type !== 'icom-network') return;
+  if (!targetKey) targetKey = icomNetworkTargetKey(target);
+  if (!isRetriableIcomNetworkConnectError(err)) return;
+  if (_icomNetworkConnectRetryKey && _icomNetworkConnectRetryKey !== targetKey) {
+    clearIcomNetworkConnectRetry(true);
+  }
+  _icomNetworkConnectRetryKey = targetKey;
+  if (_icomNetworkConnectRetryTimer) return;
+  if (_icomNetworkConnectRetryAttempts >= ICOM_NETWORK_CONNECT_RETRY_DELAYS_MS.length) {
+    const msg = `[Icom Network] Startup reconnect retries exhausted after ${_icomNetworkConnectRetryAttempts} attempt(s). The radio may still be holding a stale RS-BA1 session; fully quit other RS-BA1/wfview/SDR Control/POTACAT clients, then reconnect or restart POTACAT.`;
+    sendCatLog(msg);
+    appendIcomNetworkDiagnostic(msg);
+    return;
+  }
+  const attempt = _icomNetworkConnectRetryAttempts + 1;
+  const delay = ICOM_NETWORK_CONNECT_RETRY_DELAYS_MS[_icomNetworkConnectRetryAttempts];
+  _icomNetworkConnectRetryAttempts = attempt;
+  const code = (err && err.code) || 'connect-error';
+  const message = String((err && err.message) || err || '').split('\n')[0];
+  const msg = `[Icom Network] Connect retry ${attempt}/${ICOM_NETWORK_CONNECT_RETRY_DELAYS_MS.length} in ${(delay / 1000).toFixed(1)}s after ${code}: ${message}`;
+  sendCatLog(msg);
+  appendIcomNetworkDiagnostic(msg);
+  _icomNetworkConnectRetryTimer = setTimeout(() => {
+    _icomNetworkConnectRetryTimer = null;
+    if (!settings || !settings.catTarget || settings.catTarget.type !== 'icom-network') return;
+    if (icomNetworkTargetKey(settings.catTarget) !== targetKey) return;
+    if (cat && cat.connected) {
+      clearIcomNetworkConnectRetry(true);
+      return;
+    }
+    _icomNetworkConnectRetryActive = true;
+    connectCat()
+      .catch((retryErr) => {
+        const retryMsg = `[Icom Network] Connect retry failed to start: ${retryErr.message || retryErr}`;
+        sendCatLog(retryMsg);
+        appendIcomNetworkDiagnostic(retryMsg);
+      })
+      .finally(() => {
+        _icomNetworkConnectRetryActive = false;
+      });
+  }, delay);
+}
+
+function connectCatWithStartupDelay() {
+  const target = settings && settings.catTarget;
+  if (target && target.type === 'icom-network') {
+    const msg = `[Icom Network] Waiting ${(ICOM_NETWORK_STARTUP_CONNECT_DELAY_MS / 1000).toFixed(1)}s before startup connect so the radio can release any previous RS-BA1 session.`;
+    sendCatLog(msg);
+    appendIcomNetworkDiagnostic(msg);
+    setTimeout(() => {
+      if (!settings.enableWsjtx) connectCat();
+    }, ICOM_NETWORK_STARTUP_CONNECT_DELAY_MS);
+  } else {
+    connectCat();
+  }
+}
+
 async function connectCat() {
-  if (_connectCatPending) return; // prevent concurrent connectCat() calls
+  if (_connectCatPending) {
+    if (settings && settings.catTarget && settings.catTarget.type === 'icom-network') {
+      appendIcomNetworkDiagnostic('[Icom Network] connectCat skipped because another connect is already pending');
+    }
+    return; // prevent concurrent connectCat() calls
+  }
   // If we're in remote-client mode, the "CAT" is a shack on the other
   // end of a WebSocket — skip the local connection chain entirely.
   if (isRemoteActive()) return;
   _connectCatPending = true;
+  const dataModSession = ++_icomNetworkDataModSession;
   try {
   if (cat) {
+    await restoreIcomNetworkDataMod('reconnect');
+    stopIcomNetworkRxWatchdog();
+    resetIcomNetworkRxPacer('CAT reconnect');
     cat.removeAllListeners();
     cat.disconnect();
+    _icomNetworkTransport = null;
     // Brief delay to let serial port fully release before reconnecting
     // (prevents "Resource busy" on macOS when switching rigs)
     await new Promise(r => setTimeout(r, 300));
@@ -1677,6 +2345,9 @@ async function connectCat() {
   killRigctld();
   const target = settings.catTarget;
   if (!target) return;
+  if (target.type === 'icom-network' && !_icomNetworkConnectRetryActive && !_icomNetworkConnectRetryTimer) {
+    clearIcomNetworkConnectRetry(true);
+  }
 
   // --- New rig abstraction layer ---
   // Uses RigController (transport + codec + model) instead of ad-hoc wiring.
@@ -1878,6 +2549,7 @@ async function connectCat() {
     model.tune = getTuneQuirks(model);
     codec = new CivCodec(model, (data) => transport.write(data));
     cat = new RigController(model, transport, codec);
+    const networkCat = cat;
     cat._debug = true;
     cat.on('log', sendCatLog);
     cat.on('status', sendCatStatus);
@@ -1886,13 +2558,70 @@ async function connectCat() {
     cat.on('power', sendCatPower);
     cat.on('nb', sendCatNb);
     cat.on('smeter', sendCatSmeter);
-    cat.on('swr', sendCatSwr);
-    cat.on('alc', sendCatAlc);
-    transport.on('log', (m) => sendCatLog(m));
+	    cat.on('swr', sendCatSwr);
+	    cat.on('alc', sendCatAlc);
+	    transport.on('log', (m) => {
+	      if (!shouldKeepIcomNetworkTransportLog(m)) return;
+	      if (shouldShowIcomNetworkTransportLogInCat(m)) sendCatLog(m);
+	      appendIcomNetworkDiagnostic(m);
+	    });
     const host = target.host || '127.0.0.1';
     const controlPort = target.controlPort || target.port || 50001;
+    const connectRetryKey = icomNetworkTargetKey(target);
     const civPort = target.civPort || null; // null = use whatever the radio reports in Status
-    sendCatLog(`Connecting to Icom Network on ${host}:${controlPort} (RS-BA1 protocol)`);
+    const enableRxAudio = settings.audioSource === 'icom-network';
+    const enableTxAudio = settings.audioSource === 'icom-network' && ICOM_NETWORK_TX_AUDIO_ENABLED;
+    _icomNetworkTransport = transport;
+    _icomNetworkAudioFrameCount = 0;
+    _icomNetworkJtcatFrameCount = 0;
+    resetIcomNetworkRxDiagnostics(`connect ${host}:${controlPort}`);
+    startIcomNetworkRxWatchdog();
+    cat.on('status', (s) => {
+      if (!s || !s.connected || !enableTxAudio) return;
+      setTimeout(() => {
+        prepareIcomNetworkDataMod(networkCat, target, model, dataModSession).catch((err) => {
+          sendCatLog(`[Icom-Network-Audio] DATA MOD auto-LAN failed: ${err.message || err}`);
+        });
+      }, 700);
+    });
+    transport.on('audio-ready', () => {
+      const msg = `[Icom-Network-Audio] audio stream ready${transport.txReady ? ' (RX/TX)' : ' (RX only)'}`;
+      sendCatLog(msg);
+      appendIcomNetworkDiagnostic(msg);
+    });
+    transport.on('audio-frame', handleIcomNetworkAudioFrame);
+    transport.on('connect', () => {
+      clearIcomNetworkConnectRetry(true);
+      const msg = '[Icom Network] CI-V stream connected; startup retry state cleared.';
+      sendCatLog(msg);
+      appendIcomNetworkDiagnostic(msg);
+    });
+    transport.on('error', (err) => {
+      if (_icomNetworkTransport !== transport) return;
+      appendIcomNetworkDiagnostic(`[Icom Network] transport error ${err && err.code ? err.code + ': ' : ''}${err && err.message ? err.message : err}`);
+      if (err && err.diagnostics) {
+        try {
+          appendIcomNetworkDiagnostic(`[Icom Network] transport diagnostics ${JSON.stringify(err.diagnostics)}`);
+        } catch {}
+      }
+      scheduleIcomNetworkConnectRetry(err, connectRetryKey);
+    });
+    transport.on('close', () => {
+      appendIcomNetworkDiagnostic('[Icom Network] transport closed');
+      if (_icomNetworkTransport === transport) {
+        _icomNetworkTransport = null;
+        stopIcomNetworkRxWatchdog();
+        resetIcomNetworkRxPacer('transport close');
+      }
+    });
+    if (settings.audioSource === 'icom-network' && !enableTxAudio) {
+      const msg = '[Icom-Network-Audio] TX audio is not enabled for this connection. CAT and RX audio remain enabled.';
+      sendCatLog(msg);
+      appendIcomNetworkDiagnostic(msg);
+    }
+    const connectMsg = `Connecting to Icom Network on ${host}:${controlPort} (RS-BA1 protocol${enableRxAudio ? ', RX audio enabled' : ''}${enableTxAudio ? ', TX audio enabled' : ', TX audio disabled'})`;
+    sendCatLog(connectMsg);
+    appendIcomNetworkDiagnostic(connectMsg);
     transport.connect({
       host,
       controlPort,
@@ -1900,7 +2629,22 @@ async function connectCat() {
       username: target.username || '',
       password: target.password || '',
       compName: target.compName || 'POTACAT',
+      enableRxAudio,
+      enableTxAudio,
+      rxAudioSampleRate: 48000,
+      txAudioSampleRate: ICOM_NETWORK_TX_SAMPLE_RATE,
+      txAudioBufferMs: ICOM_NETWORK_TX_BUFFER_MS,
+      timeoutMs: 14000,
     });
+	    if (enableRxAudio) {
+	      setTimeout(() => {
+	        if (_icomNetworkTransport === transport && settings.audioSource === 'icom-network' && _icomNetworkAudioFrameCount === 0) {
+	          const msg = '[Icom-Network-Audio] No RX audio frames received after 10s. CAT/CI-V can still work while RS-BA1 audio is blocked or disabled; check the radio network audio stream, UDP audio port/firewall, and that this operator profile has Audio Source = Icom Network audio (RS-BA1).';
+	          sendCatLog(msg);
+	          appendIcomNetworkDiagnostic(msg);
+	        }
+	      }, 10_000);
+	    }
 
   } else {
     // Kenwood/Yaesu serial
@@ -3517,7 +4261,10 @@ function connectWsjtx() {
   if (!settings.enableWsjtx) return;
 
   // Release the radio so WSJT-X can control it (even on FlexRadio — dual CAT conflicts)
-  if (cat) cat.disconnect();
+  if (cat) {
+    restoreIcomNetworkDataMod('WSJT-X takeover');
+    cat.disconnect();
+  }
   killRigctld();
   sendCatStatus({ connected: false, wsjtxMode: true });
 
@@ -3773,6 +4520,8 @@ let jtcatManager = null; // initialized on first startJtcat()
 let ft8Engine = null;    // alias for jtcatManager.engine (Phase 0 compatibility)
 let remoteJtcatQso = null;
 let jtcatQuietFreq = 1500; // auto-detected quiet TX frequency from FFT analysis
+let _jtcatTxFailsafeTimer = null;
+let _jtcatIcomHardReleaseTimer = null;
 const JTCAT_MAX_CQ_RETRIES = 15;
 const JTCAT_MAX_QSO_RETRIES = 12; // ~3 minutes of retries at 15s/cycle
 
@@ -3815,6 +4564,83 @@ function broadcastAutoCqState() {
   if (remoteServer && remoteServer.hasClient()) {
     remoteServer.broadcastJtcatAutoCqState(state);
   }
+}
+
+function clearJtcatTxFailsafe() {
+  if (_jtcatTxFailsafeTimer) {
+    clearTimeout(_jtcatTxFailsafeTimer);
+    _jtcatTxFailsafeTimer = null;
+  }
+}
+
+function clearJtcatIcomHardRelease() {
+  if (_jtcatIcomHardReleaseTimer) {
+    clearTimeout(_jtcatIcomHardReleaseTimer);
+    _jtcatIcomHardReleaseTimer = null;
+  }
+}
+
+function forceReleaseIcomNetworkTx(reason = 'safety release') {
+  if (_icomNetworkTransport) {
+    try { _icomNetworkTransport.cancelTx(); } catch {}
+  }
+  logIcomNetworkAudio(`[Icom-Network-Audio] Safety release: forcing repeated PTT off (${reason})`);
+  try { handleRemotePtt(false); } catch {}
+  const delays = [0, 150, 500, 1000, 2000];
+  for (const delay of delays) {
+    setTimeout(() => {
+      try {
+        if (cat && cat.connected && typeof cat.setTransmit === 'function') {
+          cat.setTransmit(false);
+        }
+      } catch {}
+    }, delay);
+  }
+}
+
+function jtcatNetworkTxStartDelayMs(mode) {
+  const m = String(mode || 'FT8').toUpperCase();
+  if (m === 'FT4') return 300;
+  return 500;
+}
+
+function armJtcatIcomHardRelease(samples, sampleRate = 12000, offsetMs = 0, startDelayMs = 500) {
+  clearJtcatIcomHardRelease();
+  const count = samples && typeof samples.length === 'number' ? samples.length : 0;
+  const rate = Number(sampleRate) || 12000;
+  const leadMs = Math.max(0, (Number(startDelayMs) || 500) - (Number(offsetMs) || 0));
+  const timeoutMs = Math.max(5000, Math.min(25000, Math.ceil((count / rate) * 1000 + leadMs + 3500)));
+  _jtcatIcomHardReleaseTimer = setTimeout(() => {
+    _jtcatIcomHardReleaseTimer = null;
+    sendCatLog(`[Icom-Network-Audio] HARD RELEASE: forcing PTT off after ${timeoutMs} ms`);
+    if (ft8Engine && ft8Engine._txActive) {
+      try { ft8Engine.txComplete(); } catch {}
+    }
+    forceReleaseIcomNetworkTx(`hard release after ${timeoutMs}ms`);
+  }, timeoutMs);
+}
+
+function armJtcatTxFailsafe(label, samples, sampleRate = 12000, offsetMs = 0, startDelayMs = 500) {
+  clearJtcatTxFailsafe();
+  const count = samples && typeof samples.length === 'number' ? samples.length : 0;
+  const rate = Number(sampleRate) || 12000;
+  const leadMs = Math.max(0, (Number(startDelayMs) || 500) - (Number(offsetMs) || 0));
+  const expectedMs = count > 0 ? Math.ceil(count / rate * 1000 + leadMs + 2500) : 18000;
+  const timeoutMs = Math.max(5000, Math.min(30000, expectedMs));
+  _jtcatTxFailsafeTimer = setTimeout(() => {
+    _jtcatTxFailsafeTimer = null;
+    clearJtcatIcomHardRelease();
+    sendCatLog(`[JTCAT TX] FAILSAFE: forcing PTT off after ${timeoutMs} ms (${label || 'unknown TX path'})`);
+    if (smartSdrAudio) { try { smartSdrAudio.cancelTx(); } catch {} }
+    if (ft8Engine && ft8Engine._txActive) {
+      try { ft8Engine.txComplete(); } catch {}
+    }
+    if (settings.audioSource === 'icom-network') {
+      forceReleaseIcomNetworkTx(`JTCAT failsafe ${label || 'unknown TX path'}`);
+    } else {
+      try { handleRemotePtt(false); } catch {}
+    }
+  }, timeoutMs);
 }
 
 function remoteJtcatMyCall() { return (settings.myCallsign || '').toUpperCase(); }
@@ -4275,9 +5101,32 @@ function startJtcat(mode) {
 
   ft8Engine.on('tx-start', (data) => {
     const catState = cat ? `connected=${cat.connected}` : 'cat=null';
-    console.log(`[JTCAT] TX start — PTT on, message: ${data.message}, ${catState}`);
-    sendCatLog(`FT8 TX: ${data.message} freq=${data.freq}Hz slot=${data.slot} ${catState}`);
-    handleRemotePtt(true);
+    console.log(`[JTCAT] TX start requested — message: ${data.message}, ${catState}`);
+    logIcomNetworkAudio(`FT8 TX: ${data.message} freq=${data.freq}Hz slot=${data.slot} ${catState}`);
+    const smartSdrDirectTxOk = settings.audioSource === 'smartsdr' &&
+                               smartSdrAudio &&
+                               smartSdrAudio.connected &&
+                               smartSdrAudio.txReady;
+    const icomNetworkDirectTxOk = settings.audioSource === 'icom-network' &&
+                                  ICOM_NETWORK_TX_AUDIO_ENABLED &&
+                                  _icomNetworkTransport &&
+                                  _icomNetworkTransport.txReady;
+    if (settings.audioSource === 'icom-network' && !icomNetworkDirectTxOk) {
+      const connected = _icomNetworkTransport ? 'yes' : 'no';
+      const txReady = _icomNetworkTransport && _icomNetworkTransport.txReady ? 'yes' : 'no';
+      sendCatLog(`[Icom-Network-Audio] TX aborted before PTT: RS-BA1 TX audio is not ready or was not negotiated (transport=${connected}, txReady=${txReady}). CAT/RX can still work while TX audio is unavailable.`);
+      if (ft8Engine && ft8Engine._txActive) {
+        setTimeout(() => {
+          if (ft8Engine && ft8Engine._txActive) ft8Engine.txComplete();
+        }, 0);
+      }
+      return;
+    }
+
+    const modeForTx = ft8Engine ? ft8Engine._mode : 'FT8';
+    const networkStartDelayMs = jtcatNetworkTxStartDelayMs(modeForTx);
+    handleRemotePtt(true, { audio: true });
+    armJtcatTxFailsafe(settings.audioSource === 'icom-network' ? 'Icom Network RS-BA1' : (settings.audioSource === 'smartsdr' ? 'SmartSDR Direct' : 'local audio'), data.samples, 12000, data.offsetMs || 0, networkStartDelayMs);
     if (win && !win.isDestroyed()) {
       win.webContents.send('jtcat-tx-status', { state: 'tx', message: data.message, slot: data.slot });
     }
@@ -4292,7 +5141,7 @@ function startJtcat(mode) {
       remoteServer.broadcastJtcatTxStatus({ state: 'tx', message: data.message, slot: data.slot, txFreq: ft8Engine._txFreq });
     }
 
-    // Audio dispatch. Two routes:
+    // Audio dispatch. Three routes:
     //
     //   1. SmartSDR Direct TX (preferred when available) — fire FT8 audio
     //      as VITA-49 dax_tx packets straight to the radio, no Windows
@@ -4301,16 +5150,16 @@ function startJtcat(mode) {
     //      Also eliminates the 200ms IPC + renderer-scheduling latency
     //      that used to eat into the FT8 safety budget.
     //
-    //   2. Renderer Windows DAX TX route (the historical path) — kicks
+    //   2. Icom Network TX — fire FT8 audio as RS-BA1/wfview LPCM16 UDP
+    //      packets straight to the radio. This gives IP-native Icoms the
+    //      same no-virtual-audio-device path as Flex Direct.
+    //
+    //   3. Renderer Windows DAX TX route (the historical path) — kicks
     //      in when the user is on a non-SmartSDR audio source OR the
-    //      dax_tx subscribe never completed OR the direct send fails
+    //      direct-radio audio stream never completed OR direct send fails
     //      mid-cycle. Audio still goes to settings.remoteAudioOutput;
-    //      DAX program is required.
-    const directTxOk = settings.audioSource === 'smartsdr' &&
-                       smartSdrAudio &&
-                       smartSdrAudio.connected &&
-                       smartSdrAudio.txReady;
-    if (directTxOk) {
+    //      DAX/USB/virtual audio is required.
+    if (smartSdrDirectTxOk) {
       sendCatLog(`[SmartSDR-Audio] DAX TX direct → radio (bypassing Windows DAX)`);
       smartSdrAudio.sendTxAudio(data.samples, data.offsetMs || 0)
         .then(() => {
@@ -4327,6 +5176,48 @@ function startJtcat(mode) {
             win.webContents.send('jtcat-tx-audio', { samples: Array.from(data.samples), offsetMs: data.offsetMs || 0 });
           }
         });
+    } else if (icomNetworkDirectTxOk) {
+      const mode = modeForTx;
+      const startDelayMs = jtcatNetworkTxStartDelayMs(mode);
+      const envelope = analyzeDigitalTxEnvelope(data.samples, 12000, mode);
+      const networkTxGain = getIcomNetworkTxGain();
+      const txAudio = conditionDirectTxAudio(data.samples, _jtcatDirectTxGainLevel * networkTxGain, 1.0);
+      sendCatLog(`[Icom-Network-Audio] JTCAT TX profile: WSJT-X timing, ${ICOM_NETWORK_TX_SAMPLE_RATE / 1000}k LPCM mono, ${ICOM_NETWORK_TX_BUFFER_MS}ms RS-BA1 buffer, startDelay=${startDelayMs}ms, networkTxGain=${Math.round(networkTxGain * 100)}%; ${formatDigitalTxEnvelopeStats(envelope)}; ${formatDirectTxAudioStats(txAudio)}. Use radio RF power for output and keep ALC low.`);
+      // Abort before PTT if the conditioned waveform is essentially silent —
+      // catches encoder bugs that would otherwise key the radio with a silent carrier.
+      if (txAudio.outputPeak < 0.01) {
+        logIcomNetworkAudio(`[Icom-Network-Audio] TX aborted: conditioned audio peak ${txAudio.outputPeak.toFixed(4)} is too low (encoder produced silent waveform?)`);
+        if (ft8Engine && ft8Engine._txActive) ft8Engine.txComplete();
+        else handleRemotePtt(false);
+        return;
+      }
+      armJtcatIcomHardRelease(txAudio.samples, 12000, data.offsetMs || 0, startDelayMs);
+      _icomNetworkTransport.sendTxAudio(txAudio.samples, {
+        offsetMs: data.offsetMs || 0,
+        inputSampleRate: 12000,
+        startDelayMs,
+        tailSilenceMs: 200,
+      })
+        .then(() => {
+          logIcomNetworkAudio('[Icom-Network-Audio] FT8/FT4 TX audio queued to radio');
+          setTimeout(() => {
+            if (ft8Engine && ft8Engine._txActive) {
+              ft8Engine.txComplete();
+            } else {
+              handleRemotePtt(false);
+              clearJtcatIcomHardRelease();
+            }
+          }, 150);
+        })
+        .catch((e) => {
+          logIcomNetworkAudio(`[Icom-Network-Audio] Direct TX failed: ${e.message} — forcing PTT off (no local-audio fallback while Icom Network audio is selected)`);
+          if (ft8Engine && ft8Engine._txActive) {
+            ft8Engine.txComplete();
+          } else {
+            handleRemotePtt(false);
+            clearJtcatIcomHardRelease();
+          }
+        });
     } else {
       setTimeout(() => {
         if (win && !win.isDestroyed() && ft8Engine && ft8Engine._txActive) {
@@ -4336,14 +5227,21 @@ function startJtcat(mode) {
     }
   });
 
-  ft8Engine.on('tx-end', () => {
-    console.log('[JTCAT] TX end — PTT off');
-    handleRemotePtt(false);
+	  ft8Engine.on('tx-end', () => {
+	    console.log('[JTCAT] TX end — PTT off');
+	    clearJtcatTxFailsafe();
+	    clearJtcatIcomHardRelease();
+	    if (settings.audioSource === 'icom-network') {
+	      forceReleaseIcomNetworkTx('JTCAT tx-end');
+	    } else {
+	      handleRemotePtt(false);
+	    }
     // Stop the paced UDP pump if SmartSDR Direct TX was driving this cycle —
     // otherwise packets keep flowing after PTT release (harmless once the
     // radio is in RX, but wasted bandwidth, and a cancel mid-cycle would
     // bleed into the next slot).
     if (smartSdrAudio) { try { smartSdrAudio.cancelTx(); } catch {} }
+    if (_icomNetworkTransport) { try { _icomNetworkTransport.cancelTx(); } catch {} }
     if (win && !win.isDestroyed()) {
       win.webContents.send('jtcat-tx-status', { state: 'rx' });
     }
@@ -4370,6 +5268,7 @@ const jtcatTuneState = {
   endsAt: 0,        // wall-clock ms when it auto-stops
   endTimer: null,   // setTimeout ref
   tickTimer: null,  // setInterval ref for countdown broadcast
+  directIcom: false,
 };
 
 function broadcastJtcatTuneState() {
@@ -4388,13 +5287,46 @@ function broadcastJtcatTuneState() {
 
 function startJtcatTune() {
   if (jtcatTuneState.active) return;
+  const directIcomReady = settings.audioSource === 'icom-network' &&
+                          ICOM_NETWORK_TX_AUDIO_ENABLED &&
+                          _icomNetworkTransport &&
+                          _icomNetworkTransport.txReady;
+  if (settings.audioSource === 'icom-network' && !directIcomReady) {
+    sendCatLog('[Icom-Network-Audio] Tune blocked: RS-BA1 TX audio is not ready or was not negotiated. CAT/RX audio remain available.');
+    broadcastJtcatTuneState();
+    return;
+  }
   jtcatTuneState.active = true;
   jtcatTuneState.endsAt = Date.now() + JTCAT_TUNE_DURATION_S * 1000;
+  jtcatTuneState.directIcom = directIcomReady;
   // Audio is genuinely going to the rig USB CODEC, so audio:true triggers
   // SSB-over-DATA where appropriate (USB -> DIGU mute the rig mic during
   // the tone). The 90s timer auto-releases.
   handleRemotePtt(true, { audio: true });
-  if (win && !win.isDestroyed()) win.webContents.send('jtcat-tune-audio-start');
+  if (jtcatTuneState.directIcom) {
+    const networkTxGain = getIcomNetworkTxGain();
+    const tunePeak = getIcomNetworkTunePeak();
+    const tone = makeSineToneSamples(1500, JTCAT_TUNE_DURATION_S, ICOM_NETWORK_TX_SAMPLE_RATE, tunePeak);
+    const txAudio = conditionDirectTxAudio(tone, _jtcatDirectTxGainLevel);
+    sendCatLog(`[Icom-Network-Audio] Tune direct → radio: 1500 Hz sine over RS-BA1 audio (${ICOM_NETWORK_TX_SAMPLE_RATE / 1000}k LPCM, ${ICOM_NETWORK_TX_BUFFER_MS}ms buffer, networkTxGain=${Math.round(networkTxGain * 100)}%); ${formatDirectTxAudioStats(txAudio)}`);
+    _icomNetworkTransport.sendTxAudio(txAudio.samples, {
+      offsetMs: 0,
+      inputSampleRate: ICOM_NETWORK_TX_SAMPLE_RATE,
+      startDelayMs: ICOM_NETWORK_TUNE_START_DELAY_MS,
+      tailSilenceMs: 200,
+    })
+      .then(() => {
+        if (jtcatTuneState.active && jtcatTuneState.directIcom) stopJtcatTune();
+      })
+      .catch((e) => {
+        if (jtcatTuneState.active && jtcatTuneState.directIcom) {
+          sendCatLog(`[Icom-Network-Audio] Tune direct failed: ${e.message}`);
+          stopJtcatTune();
+        }
+      });
+  } else if (win && !win.isDestroyed()) {
+    win.webContents.send('jtcat-tune-audio-start');
+  }
   jtcatTuneState.endTimer = setTimeout(() => stopJtcatTune(), JTCAT_TUNE_DURATION_S * 1000);
   jtcatTuneState.tickTimer = setInterval(broadcastJtcatTuneState, 1000);
   broadcastJtcatTuneState();
@@ -4406,8 +5338,16 @@ function stopJtcatTune() {
   jtcatTuneState.active = false;
   if (jtcatTuneState.endTimer) { clearTimeout(jtcatTuneState.endTimer); jtcatTuneState.endTimer = null; }
   if (jtcatTuneState.tickTimer) { clearInterval(jtcatTuneState.tickTimer); jtcatTuneState.tickTimer = null; }
-  if (win && !win.isDestroyed()) win.webContents.send('jtcat-tune-audio-stop');
-  handleRemotePtt(false);
+  const wasDirectIcom = jtcatTuneState.directIcom;
+  jtcatTuneState.directIcom = false;
+  if (wasDirectIcom && _icomNetworkTransport) {
+    forceReleaseIcomNetworkTx('Tune OFF');
+  } else if (win && !win.isDestroyed()) {
+    win.webContents.send('jtcat-tune-audio-stop');
+    handleRemotePtt(false);
+  } else {
+    handleRemotePtt(false);
+  }
   broadcastJtcatTuneState();
   sendCatLog('[JTCAT] Tune OFF');
 }
@@ -4450,6 +5390,15 @@ function stopInProcessSpectrum() {
 }
 
 function stopJtcat() {
+  clearJtcatTxFailsafe();
+  clearJtcatIcomHardRelease();
+  if (smartSdrAudio) { try { smartSdrAudio.cancelTx(); } catch {} }
+  if (settings.audioSource === 'icom-network') {
+    forceReleaseIcomNetworkTx('JTCAT stop');
+  } else {
+    if (_icomNetworkTransport) { try { _icomNetworkTransport.cancelTx(); } catch {} }
+    try { handleRemotePtt(false); } catch {}
+  }
   // Spectrum loop has no reason to keep running once the engine is
   // gone — audioBuffer reads would all return zeros anyway. Mobile
   // re-subscribes on the next FT8-tab open.
@@ -4799,6 +5748,607 @@ function stopSmartSdrAudio() {
   if (!smartSdrAudio) return;
   try { smartSdrAudio.stop(); } catch {}
   smartSdrAudio = null;
+}
+
+function resampleMonoFloat32(input, fromRate, toRate) {
+  const src = (input instanceof Float32Array) ? input : new Float32Array(input || []);
+  if (!src.length) return new Float32Array(0);
+  if (!fromRate || !toRate || fromRate === toRate) return src;
+  const outLen = Math.max(1, Math.round(src.length * toRate / fromRate));
+  const out = new Float32Array(outLen);
+  const step = fromRate / toRate;
+  for (let i = 0; i < outLen; i++) {
+    const pos = i * step;
+    const i0 = Math.floor(pos);
+    const i1 = Math.min(i0 + 1, src.length - 1);
+    const frac = pos - i0;
+    out[i] = src[i0] + (src[i1] - src[i0]) * frac;
+  }
+  return out;
+}
+
+function concatFloat32Chunks(chunks, totalSamples) {
+  if (!chunks || !chunks.length || !totalSamples) return new Float32Array(0);
+  if (chunks.length === 1 && chunks[0].length === totalSamples) return chunks[0];
+  const out = new Float32Array(totalSamples);
+  let offset = 0;
+  for (const chunk of chunks) {
+    if (!chunk || !chunk.length) continue;
+    out.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return out;
+}
+
+function peakFloat32(samples) {
+  let peak = 0;
+  if (!samples) return peak;
+  for (let i = 0; i < samples.length; i++) {
+    const v = Math.abs(samples[i]);
+    if (v > peak) peak = v;
+  }
+  return peak;
+}
+
+class IcomNetworkRxPacer {
+  constructor(opts) {
+    this.sampleRate = opts.sampleRate || 48000;
+    this.frameMs = opts.frameMs || 20;
+    this.startBufferMs = opts.startBufferMs || 2200;
+    this.resumeBufferMs = opts.resumeBufferMs || 1400;
+    this.maxBufferMs = opts.maxBufferMs || 5200;
+    this.onFrame = opts.onFrame;
+    this.chunks = [];
+    this.totalSamples = 0;
+    this.timer = null;
+    this.buffering = true;
+    this.targetBufferMs = this.startBufferMs;
+    this.framesOut = 0;
+    this.underruns = 0;
+    this.drops = 0;
+    this.started = false;
+    this.lastLogMs = 0;
+  }
+
+  reset(reason = 'reset') {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    this.chunks = [];
+    this.totalSamples = 0;
+    this.buffering = true;
+    this.targetBufferMs = this.startBufferMs;
+    this.framesOut = 0;
+    this.underruns = 0;
+    this.drops = 0;
+    this.started = false;
+    this.lastLogMs = 0;
+    appendDiagnosticLog('rsba1-rx-diagnostics.log', `RX-PACER reset reason="${reason}"`);
+  }
+
+  push(pcm, sampleRate) {
+    if (!pcm || !pcm.length) return;
+    const rate = sampleRate || this.sampleRate;
+    if (rate !== this.sampleRate) {
+      this.sampleRate = rate;
+      this.reset(`sample-rate-change ${rate}`);
+    }
+    this.chunks.push(pcm instanceof Float32Array ? pcm : new Float32Array(pcm));
+    this.totalSamples += pcm.length;
+    this._trimToMaxBuffer();
+    if (!this.timer) {
+      this.timer = setInterval(() => this._tick(), this.frameMs);
+    }
+  }
+
+  bufferedMs() {
+    return this.sampleRate ? (this.totalSamples / this.sampleRate * 1000) : 0;
+  }
+
+  _trimToMaxBuffer() {
+    const maxSamples = Math.max(1, Math.round(this.sampleRate * this.maxBufferMs / 1000));
+    if (this.totalSamples <= maxSamples) return;
+    const drop = this.totalSamples - maxSamples;
+    this._dropSamples(drop);
+    this.drops++;
+    const now = Date.now();
+    if (now - this.lastLogMs > 1000) {
+      appendDiagnosticLog('rsba1-rx-diagnostics.log', `RX-PACER drop samples=${drop} bufferedMs=${this.bufferedMs().toFixed(0)} drops=${this.drops}`);
+      this.lastLogMs = now;
+    }
+  }
+
+  _tick() {
+    const frameSamples = Math.max(1, Math.round(this.sampleRate * this.frameMs / 1000));
+    const now = Date.now();
+
+    // Emit catch-up frames when the event loop fired this tick late. Without
+    // this, a 80-180ms Node.js GC/render lag causes the worklet ring buffer to
+    // drain and underrun because only one frame is sent for multiple periods.
+    const elapsed = this._lastTickMs ? now - this._lastTickMs : this.frameMs;
+    this._lastTickMs = now;
+    const catchUpFrames = Math.min(4, Math.max(1, Math.round(elapsed / this.frameMs)));
+
+    for (let f = 0; f < catchUpFrames; f++) {
+      if (this.buffering) {
+        if (this.bufferedMs() < this.targetBufferMs) {
+          this._emitSilence(frameSamples, true);
+          continue;
+        }
+        this.buffering = false;
+        appendDiagnosticLog('rsba1-rx-diagnostics.log', `RX-PACER ${this.started ? 'resume' : 'start'} bufferedMs=${this.bufferedMs().toFixed(0)} targetMs=${this.targetBufferMs}`);
+        this.started = true;
+      }
+
+      if (this.totalSamples < frameSamples) {
+        this.underruns++;
+        appendDiagnosticLog('rsba1-rx-diagnostics.log', `RX-PACER underrun bufferedMs=${this.bufferedMs().toFixed(0)} underruns=${this.underruns}`);
+        this.buffering = true;
+        this.targetBufferMs = this.resumeBufferMs;
+        this._emitSilence(frameSamples, true);
+        break;
+      }
+
+      const pcm = this._consumeSamples(frameSamples);
+      this.framesOut++;
+      if (this.onFrame) this.onFrame(pcm, this.sampleRate, { silence: false, bufferedMs: this.bufferedMs() });
+    }
+  }
+
+  _emitSilence(frameSamples, buffering) {
+    this.framesOut++;
+    if (this.onFrame) {
+      this.onFrame(new Float32Array(frameSamples), this.sampleRate, {
+        silence: true,
+        buffering: !!buffering,
+        bufferedMs: this.bufferedMs(),
+      });
+    }
+  }
+
+  _consumeSamples(count) {
+    const out = new Float32Array(count);
+    let offset = 0;
+    while (offset < count && this.chunks.length) {
+      const chunk = this.chunks[0];
+      const take = Math.min(chunk.length, count - offset);
+      out.set(chunk.subarray(0, take), offset);
+      offset += take;
+      if (take === chunk.length) {
+        this.chunks.shift();
+      } else {
+        this.chunks[0] = chunk.subarray(take);
+      }
+      this.totalSamples -= take;
+    }
+    return out;
+  }
+
+  _dropSamples(count) {
+    let remaining = count;
+    while (remaining > 0 && this.chunks.length) {
+      const chunk = this.chunks[0];
+      const take = Math.min(chunk.length, remaining);
+      remaining -= take;
+      this.totalSamples -= take;
+      if (take === chunk.length) {
+        this.chunks.shift();
+      } else {
+        this.chunks[0] = chunk.subarray(take);
+      }
+    }
+  }
+}
+
+let _icomNetworkAudioFrameCount = 0;
+let _icomNetworkJtcatFrameCount = 0;
+let _icomNetworkRxDiag = null;
+let _icomNetworkRxWatchdogTimer = null;
+let _icomNetworkRxLastRecoveryMs = 0;
+let _icomNetworkRxAudioRestartAttempts = 0;
+let _icomNetworkRxFullReconnectPending = false;
+let _icomNetworkRxPacer = null;
+let _icomNetworkEventLoopTimer = null;
+let _icomNetworkEventLoopExpectedMs = 0;
+let _icomNetworkEventLoopMaxLagMs = 0;
+let _icomNetworkEventLoopLastLagMs = 0;
+let _icomNetworkEventLoopLastLagAtMs = 0;
+let _icomNetworkJtcatUiChunks = [];
+let _icomNetworkJtcatUiSampleCount = 0;
+let _icomNetworkJtcatUiSampleRate = 0;
+let _icomNetworkJtcatUiPeak = 0;
+let _icomNetworkJtcatReadyNudgeMs = 0;
+// PLC: last non-fill, non-silence frame; used to repeat audio during loss gaps
+// instead of injecting silence (especially important for SSTV tone continuity).
+let _lastGoodIcomNetworkPcm = null;
+const ICOM_NETWORK_JTCAT_UI_FRAME_MS = 20;
+const ICOM_NETWORK_RX_PACER_FRAME_MS = 20;
+const ICOM_NETWORK_RX_PACER_START_MS = 1000;
+const ICOM_NETWORK_RX_PACER_RESUME_MS = 150;
+const ICOM_NETWORK_RX_PACER_MAX_MS = 5400;
+const ICOM_NETWORK_RX_STALL_MS = 1200;
+const ICOM_NETWORK_RX_RESTART_STALL_MS = 8000;
+const ICOM_NETWORK_RX_RECOVERY_COOLDOWN_MS = 2500;
+const ICOM_NETWORK_RX_FULL_RECONNECT_AFTER_AUDIO_RESTARTS = 3;
+const ICOM_NETWORK_RX_LOSSFILL_MAX_MS = 240;
+const ICOM_NETWORK_RX_LOSSFILL_MAX_ARRIVAL_GAP_MS = 120;
+const ICOM_NETWORK_EVENT_LOOP_PERIOD_MS = 100;
+const ICOM_NETWORK_EVENT_LOOP_LOG_LAG_MS = 180;
+
+function stopIcomNetworkEventLoopMonitor() {
+  if (_icomNetworkEventLoopTimer) {
+    clearInterval(_icomNetworkEventLoopTimer);
+    _icomNetworkEventLoopTimer = null;
+  }
+}
+
+function startIcomNetworkEventLoopMonitor() {
+  stopIcomNetworkEventLoopMonitor();
+  _icomNetworkEventLoopExpectedMs = Date.now() + ICOM_NETWORK_EVENT_LOOP_PERIOD_MS;
+  _icomNetworkEventLoopMaxLagMs = 0;
+  _icomNetworkEventLoopLastLagMs = 0;
+  _icomNetworkEventLoopLastLagAtMs = 0;
+  _icomNetworkEventLoopTimer = setInterval(() => {
+    const now = Date.now();
+    const lag = now - _icomNetworkEventLoopExpectedMs;
+    _icomNetworkEventLoopExpectedMs = now + ICOM_NETWORK_EVENT_LOOP_PERIOD_MS;
+    if (lag <= ICOM_NETWORK_EVENT_LOOP_LOG_LAG_MS) return;
+    if (settings.audioSource !== 'icom-network' || !_icomNetworkRxDiag) return;
+    _icomNetworkEventLoopLastLagMs = lag;
+    _icomNetworkEventLoopLastLagAtMs = now;
+    _icomNetworkEventLoopMaxLagMs = Math.max(_icomNetworkEventLoopMaxLagMs, lag);
+    const sinceFrame = _icomNetworkRxDiag.lastFrameMs ? now - _icomNetworkRxDiag.lastFrameMs : 0;
+    const msg = `EVENTLOOP-LAG lag=${Math.round(lag)}ms max=${Math.round(_icomNetworkEventLoopMaxLagMs)}ms sinceLastFrame=${sinceFrame}ms`;
+    appendDiagnosticLog('rsba1-rx-diagnostics.log', msg);
+    if (lag >= 500) sendCatLog(`[Icom-Network-Audio] ${msg}`);
+  }, ICOM_NETWORK_EVENT_LOOP_PERIOD_MS);
+}
+
+function resetIcomNetworkJtcatUiBuffer() {
+  _icomNetworkJtcatUiChunks = [];
+  _icomNetworkJtcatUiSampleCount = 0;
+  _icomNetworkJtcatUiSampleRate = 0;
+  _icomNetworkJtcatUiPeak = 0;
+}
+
+function resetIcomNetworkRxPacer(reason = 'reset') {
+  if (_icomNetworkRxPacer) _icomNetworkRxPacer.reset(reason);
+}
+
+function resetIcomNetworkRxDiagnostics(reason = 'reset') {
+  resetIcomNetworkJtcatUiBuffer();
+  resetIcomNetworkRxPacer(reason);
+  startIcomNetworkEventLoopMonitor();
+  _icomNetworkRxDiag = {
+    startedMs: Date.now(),
+    lastFrameMs: 0,
+    lastSummaryMs: Date.now(),
+    frames: 0,
+    gapEvents: 0,
+    maxGapMs: 0,
+    seqGapEvents: 0,
+    missingAdded: 0,
+    missingRecovered: 0,
+    duplicates: 0,
+    largeGaps: 0,
+    peakMax: 0,
+    payloads: new Map(),
+    sampleRates: new Map(),
+    stalled: false,
+    stallStartMs: 0,
+  };
+  appendDiagnosticLog('rsba1-rx-diagnostics.log', `--- ${reason}; activeProfile=${settings && settings.activeProfile || ''}; audioSource=${settings && settings.audioSource || ''}; catTarget=${settings && settings.catTarget && settings.catTarget.type || ''} ---`);
+}
+
+function stopIcomNetworkRxWatchdog() {
+  if (_icomNetworkRxWatchdogTimer) {
+    clearInterval(_icomNetworkRxWatchdogTimer);
+    _icomNetworkRxWatchdogTimer = null;
+  }
+  stopIcomNetworkEventLoopMonitor();
+  _icomNetworkRxFullReconnectPending = false;
+}
+
+function startIcomNetworkRxWatchdog() {
+  stopIcomNetworkRxWatchdog();
+  _icomNetworkRxLastRecoveryMs = 0;
+  _icomNetworkRxAudioRestartAttempts = 0;
+  _icomNetworkRxFullReconnectPending = false;
+  _icomNetworkRxWatchdogTimer = setInterval(() => {
+    if (settings.audioSource !== 'icom-network' || !_icomNetworkTransport || !_icomNetworkRxDiag) return;
+    const d = _icomNetworkRxDiag;
+    if (!d.lastFrameMs || d.frames <= 0) return;
+    const now = Date.now();
+    const quietMs = now - d.lastFrameMs;
+    if (quietMs < ICOM_NETWORK_RX_STALL_MS) return;
+    if (!d.stalled) {
+      d.stalled = true;
+      d.stallStartMs = d.lastFrameMs;
+      const msg = `RX-STALL noFramesFor=${quietMs}ms frame=${_icomNetworkAudioFrameCount} gaps=${d.gapEvents} seqGaps=${d.seqGapEvents} missingAdded=${d.missingAdded} recovered=${d.missingRecovered} dupes=${d.duplicates} largeGaps=${d.largeGaps}`;
+      appendDiagnosticLog('rsba1-rx-diagnostics.log', msg);
+      sendCatLog(`[Icom-Network-Audio] ${msg}`);
+    }
+    if (quietMs < ICOM_NETWORK_RX_RESTART_STALL_MS) return;
+    if (now - _icomNetworkRxLastRecoveryMs < ICOM_NETWORK_RX_RECOVERY_COOLDOWN_MS) return;
+    _icomNetworkRxLastRecoveryMs = now;
+    _icomNetworkRxAudioRestartAttempts++;
+    const reason = `RX stalled ${quietMs}ms (attempt ${_icomNetworkRxAudioRestartAttempts})`;
+    if (_icomNetworkRxAudioRestartAttempts >= ICOM_NETWORK_RX_FULL_RECONNECT_AFTER_AUDIO_RESTARTS) {
+      if (_icomNetworkRxFullReconnectPending) return;
+      _icomNetworkRxFullReconnectPending = true;
+      const msg = `RX-RECOVERY full CAT reconnect requested after ${_icomNetworkRxAudioRestartAttempts} stalled audio restart attempt(s): ${reason}`;
+      appendDiagnosticLog('rsba1-rx-diagnostics.log', msg);
+      sendCatLog(`[Icom-Network-Audio] ${msg}`);
+      connectCat()
+        .catch((err) => {
+          appendDiagnosticLog('rsba1-rx-diagnostics.log', `RX-RECOVERY full CAT reconnect failed: ${err.message || err}`);
+        })
+        .finally(() => {
+          _icomNetworkRxFullReconnectPending = false;
+        });
+      return;
+    }
+    let restarted = false;
+    try {
+      restarted = !!(_icomNetworkTransport && _icomNetworkTransport.restartAudioStream && _icomNetworkTransport.restartAudioStream(reason));
+    } catch (err) {
+      appendDiagnosticLog('rsba1-rx-diagnostics.log', `RX-RECOVERY audio-restart-error ${err.message || err}`);
+    }
+    appendDiagnosticLog('rsba1-rx-diagnostics.log', `RX-RECOVERY audio-restart attempted=${restarted ? 1 : 0} reason="${reason}"`);
+    if (!restarted && _icomNetworkRxAudioRestartAttempts >= 2) {
+      appendDiagnosticLog('rsba1-rx-diagnostics.log', 'RX-RECOVERY full CAT reconnect requested');
+      connectCat().catch((err) => {
+        appendDiagnosticLog('rsba1-rx-diagnostics.log', `RX-RECOVERY full CAT reconnect failed: ${err.message || err}`);
+      });
+    }
+  }, 250);
+}
+
+function incDiagMap(map, key) {
+  if (!map) return;
+  const k = String(key);
+  map.set(k, (map.get(k) || 0) + 1);
+}
+
+function diagMapTop(map, limit = 5) {
+  if (!map || !map.size) return '-';
+  return Array.from(map.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([k, v]) => `${k}:${v}`)
+    .join(',');
+}
+
+function sendIcomNetworkJtcatUiAudio(pcm, sampleRate, peak, jtcatRunning) {
+  if (!pcm || !pcm.length) return;
+  const jtcatFrame = { pcm: resampleMonoFloat32(pcm, sampleRate, 24000), sampleRate: 24000 };
+  const popoutReady = isJtcatIpAudioReady(jtcatPopoutWin);
+  const mainReady = isJtcatIpAudioReady(win);
+  if (popoutReady) {
+    audioSafeSend(jtcatPopoutWin.webContents, 'jtcat-vita49-audio', jtcatFrame);
+  } else if (mainReady) {
+    audioSafeSend(win.webContents, 'jtcat-vita49-audio', jtcatFrame);
+  } else if (_icomNetworkJtcatFrameCount === 0 || _icomNetworkJtcatFrameCount % 250 === 0) {
+    appendDiagnosticLog('rsba1-rx-diagnostics.log', `JTCAT-IP-AUDIO-NO-READY main=${win && !win.isDestroyed() ? win.webContents.id : 0} popout=${jtcatPopoutWin && !jtcatPopoutWin.isDestroyed() ? jtcatPopoutWin.webContents.id : 0}`);
+  }
+  if (!popoutReady && !mainReady && jtcatRunning) {
+    const now = Date.now();
+    const targetWin = jtcatPopoutWin && !jtcatPopoutWin.isDestroyed() ? jtcatPopoutWin : win;
+    const eventName = targetWin === jtcatPopoutWin ? 'restart-popout-audio' : 'restart-jtcat-audio';
+    if (targetWin && !targetWin.isDestroyed() && now - _icomNetworkJtcatReadyNudgeMs >= 10_000) {
+      _icomNetworkJtcatReadyNudgeMs = now;
+      appendDiagnosticLog('rsba1-rx-diagnostics.log', `JTCAT-IP-AUDIO-NUDGE event=${eventName} wc=${targetWin.webContents.id}`);
+      targetWin.webContents.send(eventName);
+    }
+  }
+  _icomNetworkJtcatFrameCount++;
+  if (_icomNetworkJtcatFrameCount === 1 || _icomNetworkJtcatFrameCount % 100 === 0) {
+    sendCatLog(`[Icom-Network-Audio] JTCAT UI RX frame #${_icomNetworkJtcatFrameCount}: decoder=${jtcatRunning ? 'yes' : 'no'} mainWin=${mainReady ? 'yes' : 'no'} popout=${popoutReady ? 'yes' : 'no'} ${pcm.length} samples @${sampleRate}Hz peak=${(peak || 0).toFixed(4)}`);
+  }
+}
+
+function queueIcomNetworkJtcatUiAudio(pcm, sampleRate, peak, jtcatRunning) {
+  if (!pcm || !pcm.length || !sampleRate) return;
+  if (_icomNetworkJtcatUiSampleRate && _icomNetworkJtcatUiSampleRate !== sampleRate) {
+    resetIcomNetworkJtcatUiBuffer();
+  }
+  _icomNetworkJtcatUiSampleRate = sampleRate;
+  _icomNetworkJtcatUiChunks.push(pcm);
+  _icomNetworkJtcatUiSampleCount += pcm.length;
+  _icomNetworkJtcatUiPeak = Math.max(_icomNetworkJtcatUiPeak, peak || 0);
+
+  const targetSamples = Math.max(1, Math.round(sampleRate * ICOM_NETWORK_JTCAT_UI_FRAME_MS / 1000));
+  if (_icomNetworkJtcatUiSampleCount < targetSamples) return;
+
+  const combined = concatFloat32Chunks(_icomNetworkJtcatUiChunks, _icomNetworkJtcatUiSampleCount);
+  const combinedPeak = _icomNetworkJtcatUiPeak;
+  resetIcomNetworkJtcatUiBuffer();
+  sendIcomNetworkJtcatUiAudio(combined, sampleRate, combinedPeak, jtcatRunning);
+}
+
+function handleIcomNetworkPacedRxFrame(pcm, sampleRate, meta = {}) {
+  if (!pcm || !pcm.length) return;
+  const peak = meta.silence ? 0 : peakFloat32(pcm);
+
+  // PLC: track last real (non-fill, non-silence) frame so loss-fill gaps can
+  // repeat it rather than injecting silence. Repeating the last frame preserves
+  // SSTV tone continuity and slightly improves FT8 SNR vs zero-filling.
+  if (!meta.silence && !meta.lossFill && peak > 0.001) {
+    _lastGoodIcomNetworkPcm = pcm;
+  }
+
+  if (remoteAudioWin) {
+    audioSafeSend(remoteAudioWin.webContents, 'smartsdr-audio-frame', { pcm, sampleRate });
+  }
+  if (vfoPopoutWin) {
+    audioSafeSend(vfoPopoutWin.webContents, 'smartsdr-audio-frame', { pcm, sampleRate });
+  }
+
+  if (settings.audioSource === 'icom-network') {
+    const jtcatRunning = !!((jtcatManager && jtcatManager.running) || (ft8Engine && ft8Engine._running));
+    if (jtcatManager && jtcatManager.running) {
+      jtcatManager.feedAudio('default', resampleMonoFloat32(pcm, sampleRate, 12000));
+    } else if (ft8Engine && ft8Engine._running) {
+      ft8Engine.feedAudio(resampleMonoFloat32(pcm, sampleRate, 12000));
+    }
+    queueIcomNetworkJtcatUiAudio(pcm, sampleRate, peak, jtcatRunning);
+  }
+
+  if (settings.audioSource === 'icom-network' && sstvEngine && !_sstvFeedPaused) {
+    // sstvEngine.feedAudio transfers the ArrayBuffer to its worker. Use a
+    // private copy so the same paced frame can safely feed JTCAT/UI/monitor
+    // consumers first.
+    const sstvPcm = sampleRate === 48000
+      ? new Float32Array(pcm)
+      : resampleMonoFloat32(pcm, sampleRate, 48000);
+    if (sstvPopoutWin) {
+      audioSafeSend(sstvPopoutWin.webContents, 'sstv-vita49-audio', { pcm: new Float32Array(sstvPcm), sampleRate: 48000 });
+    }
+    sstvEngine.feedAudio(sstvPcm);
+  }
+
+  if (meta.silence && meta.buffering && _icomNetworkRxPacer && _icomNetworkRxPacer.framesOut % 100 === 0) {
+    appendDiagnosticLog('rsba1-rx-diagnostics.log', `RX-PACER buffering-silence framesOut=${_icomNetworkRxPacer.framesOut} bufferedMs=${_icomNetworkRxPacer.bufferedMs().toFixed(0)}`);
+  }
+}
+
+function estimateIcomNetworkMissingSamples(missingPackets, currentSamples, sampleRate) {
+  const count = Math.max(0, Math.min(128, Number(missingPackets) || 0));
+  const rate = sampleRate || 48000;
+  if (!count) return 0;
+  const samples = Number(currentSamples) || 0;
+  const pairSamples = Math.max(1, Math.round(rate * 0.02));
+  const otherSamples = pairSamples - samples;
+  if (samples > 0 && otherSamples > 0 && otherSamples < pairSamples) {
+    let total = 0;
+    for (let i = 1; i <= count; i++) total += (i % 2 === 1) ? otherSamples : samples;
+    return total;
+  }
+  return Math.round(rate * 0.01 * count);
+}
+
+function getIcomNetworkRxPacer() {
+  if (!_icomNetworkRxPacer) {
+    _icomNetworkRxPacer = new IcomNetworkRxPacer({
+      sampleRate: 48000,
+      frameMs: ICOM_NETWORK_RX_PACER_FRAME_MS,
+      startBufferMs: ICOM_NETWORK_RX_PACER_START_MS,
+      resumeBufferMs: ICOM_NETWORK_RX_PACER_RESUME_MS,
+      maxBufferMs: ICOM_NETWORK_RX_PACER_MAX_MS,
+      onFrame: handleIcomNetworkPacedRxFrame,
+    });
+  }
+  return _icomNetworkRxPacer;
+}
+
+function noteIcomNetworkRxDiagnostics(frame, pcm, sampleRate, peak) {
+  if (!_icomNetworkRxDiag) resetIcomNetworkRxDiagnostics('RX diagnostics start');
+  const d = _icomNetworkRxDiag;
+  const now = Date.now();
+  const dt = d.lastFrameMs ? now - d.lastFrameMs : 0;
+  if (d.stalled) {
+    const stalledMs = d.stallStartMs ? now - d.stallStartMs : dt;
+    const msg = `RX-RECOVERED after=${stalledMs}ms frame=${_icomNetworkAudioFrameCount + 1} packetSeq=${frame.packetSeq ?? '-'} audioSeq=${frame.audioSeq ?? '-'}`;
+    appendDiagnosticLog('rsba1-rx-diagnostics.log', msg);
+    sendCatLog(`[Icom-Network-Audio] ${msg}`);
+    d.stalled = false;
+    d.stallStartMs = 0;
+    _icomNetworkRxAudioRestartAttempts = 0;
+  }
+  d.lastFrameMs = now;
+  d.frames++;
+  d.peakMax = Math.max(d.peakMax, peak || 0);
+  incDiagMap(d.payloads, frame.payloadBytes || (pcm.length * 2));
+  incDiagMap(d.sampleRates, sampleRate);
+
+  if (dt > 180) {
+    d.gapEvents++;
+    d.maxGapMs = Math.max(d.maxGapMs, dt);
+    const expectedMs = pcm.length && sampleRate ? (pcm.length / sampleRate * 1000) : 0;
+    const lagAge = _icomNetworkEventLoopLastLagAtMs ? now - _icomNetworkEventLoopLastLagAtMs : 0;
+    const recentLag = lagAge > 0 && lagAge <= 2500 ? Math.round(_icomNetworkEventLoopLastLagMs) : 0;
+    const msg = `RX-GAP dt=${dt}ms expected=${expectedMs.toFixed(1)}ms frame=${_icomNetworkAudioFrameCount} packetSeq=${frame.packetSeq ?? '-'} audioSeq=${frame.audioSeq ?? '-'} payload=${frame.payloadBytes ?? '-'} peak=${(peak || 0).toFixed(4)} eventLoopLag=${recentLag}ms`;
+    appendDiagnosticLog('rsba1-rx-diagnostics.log', msg);
+    sendCatLog(`[Icom-Network-Audio] ${msg}`);
+  }
+
+  const track = frame.rxTrack || {};
+  if (track.missingAdded || track.missingRecovered || track.duplicate || track.largeGap) {
+    if (track.missingAdded) {
+      d.seqGapEvents++;
+      d.missingAdded += track.missingAdded;
+    }
+    if (track.missingRecovered) d.missingRecovered++;
+    if (track.duplicate) d.duplicates++;
+    if (track.largeGap) d.largeGaps++;
+    if (track.missingAdded || track.missingRecovered || track.largeGap) {
+      const msg = `RX-SEQ frame=${_icomNetworkAudioFrameCount} seq=${frame.packetSeq ?? '-'} audioSeq=${frame.audioSeq ?? '-'} missingAdded=${track.missingAdded || 0} pending=${track.pendingMissing || 0} recovered=${track.missingRecovered ? 1 : 0} duplicate=${track.duplicate ? 1 : 0} largeGap=${track.largeGap ? 1 : 0} payload=${frame.payloadBytes ?? '-'} peak=${(peak || 0).toFixed(4)}`;
+      appendDiagnosticLog('rsba1-rx-diagnostics.log', msg);
+      if (track.missingAdded || track.largeGap) sendCatLog(`[Icom-Network-Audio] ${msg}`);
+    }
+  }
+
+  if (now - d.lastSummaryMs >= 10_000) {
+    const elapsedSec = Math.max(1, (now - d.startedMs) / 1000);
+    const msg = `RX-SUMMARY frames=${d.frames} rate=${(d.frames / elapsedSec).toFixed(1)}/s gaps=${d.gapEvents} maxGap=${Math.round(d.maxGapMs)}ms seqGaps=${d.seqGapEvents} missingAdded=${d.missingAdded} recovered=${d.missingRecovered} dupes=${d.duplicates} largeGaps=${d.largeGaps} payloads=${diagMapTop(d.payloads)} sampleRates=${diagMapTop(d.sampleRates)} peakMax=${d.peakMax.toFixed(4)}`;
+    appendDiagnosticLog('rsba1-rx-diagnostics.log', msg);
+    if (d.gapEvents || d.seqGapEvents || d.duplicates || d.largeGaps) {
+      sendCatLog(`[Icom-Network-Audio] ${msg}`);
+    }
+    d.lastSummaryMs = now;
+  }
+  return dt;
+}
+
+function handleIcomNetworkAudioFrame(frame) {
+  if (!frame || !frame.pcm) return;
+  const sampleRate = frame.sampleRate || 48000;
+  const pcm = (frame.pcm instanceof Float32Array) ? frame.pcm : new Float32Array(frame.pcm);
+  if (!pcm.length) return;
+  _icomNetworkAudioFrameCount++;
+  const peak = peakFloat32(pcm);
+  const arrivalGapMs = noteIcomNetworkRxDiagnostics(frame, pcm, sampleRate, peak);
+  const track = frame.rxTrack || {};
+
+  if (track.duplicate || track.missingRecovered) {
+    appendDiagnosticLog('rsba1-rx-diagnostics.log', `RX-SKIP-LATE frame=${_icomNetworkAudioFrameCount} seq=${frame.packetSeq ?? '-'} recovered=${track.missingRecovered ? 1 : 0} duplicate=${track.duplicate ? 1 : 0} payload=${frame.payloadBytes ?? '-'}`);
+    return;
+  }
+  if (track.largeGap) {
+    resetIcomNetworkJtcatUiBuffer();
+  }
+
+  // Keep Icom Network RX low-latency for FT8/FT4 and band changes. A deep
+  // wfview-style playback buffer is useful for ears, but it makes JTCAT's
+  // decode window stale and can leave the waterfall showing the old band
+  // after CAT has already QSY'd. Feed consumers from current packets and let
+  // the watchdog recover true RS-BA1 stream stalls.
+  if (track.missingAdded && !track.largeGap && arrivalGapMs <= ICOM_NETWORK_RX_LOSSFILL_MAX_ARRIVAL_GAP_MS) {
+    const fillSamples = estimateIcomNetworkMissingSamples(track.missingAdded, pcm.length, sampleRate);
+    const maxFillSamples = Math.round((sampleRate || 48000) * ICOM_NETWORK_RX_LOSSFILL_MAX_MS / 1000);
+    const cappedSamples = Math.min(fillSamples, maxFillSamples);
+    if (cappedSamples > 0) {
+      // PLC: tile the last good frame instead of inserting silence. This preserves
+      // SSTV tone continuity across packet gaps. For FT8 the repeat is better than
+      // silence too (adds a small copy of real signal rather than a zero gap).
+      let fillPcm;
+      if (_lastGoodIcomNetworkPcm && _lastGoodIcomNetworkPcm.length > 0) {
+        fillPcm = new Float32Array(cappedSamples);
+        const src = _lastGoodIcomNetworkPcm;
+        for (let i = 0; i < cappedSamples; i++) fillPcm[i] = src[i % src.length];
+      } else {
+        fillPcm = new Float32Array(cappedSamples);
+      }
+      appendDiagnosticLog('rsba1-rx-diagnostics.log', `RX-LOSSFILL packets=${track.missingAdded} samples=${cappedSamples}${cappedSamples < fillSamples ? `/${fillSamples}` : ''} arrivalGap=${arrivalGapMs}ms beforeSeq=${frame.packetSeq ?? '-'} plc=${_lastGoodIcomNetworkPcm ? 'repeat' : 'silence'}`);
+      handleIcomNetworkPacedRxFrame(fillPcm, sampleRate, { silence: false, lossFill: true });
+    }
+  }
+  handleIcomNetworkPacedRxFrame(pcm, sampleRate, { silence: false });
+
+  if (_icomNetworkAudioFrameCount === 1 || _icomNetworkAudioFrameCount % 100 === 0) {
+    sendCatLog(`[Icom-Network-Audio] RX frame #${_icomNetworkAudioFrameCount}: ${pcm.length} samples @ ${sampleRate} Hz, peak=${peak.toFixed(4)}`);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -6270,7 +7820,7 @@ function connectRemote() {
   // Surface our package version in the v1 protocol `hello` so connected
   // clients can show "POTACAT desktop 1.5.13" and decide whether to
   // suggest an update.
-  try { remoteServer._serverVersion = String(app.getVersion() || ''); } catch {}
+  try { remoteServer._serverVersion = String(getAppDisplayVersion() || ''); } catch {}
   // Active rig model surfaced in the v1 server `hello` so POTACAT
   // desktop clients (Remote Radios panel) can distinguish multiple
   // paired shacks. Empty when no rig configured — falls back to
@@ -6282,7 +7832,12 @@ function connectRemote() {
   } catch {}
   // Hydrate paired-devices list from settings.json. The list survives
   // across desktop restarts; revoking from settings UI removes a device.
-  try { remoteServer.setPairedDevices(settings.pairedDevices || []); } catch {}
+  // Load paired devices from ALL operator profiles so any phone can auth
+  // regardless of which profile is currently active on the desktop.
+  try { remoteServer.setPairedDevices(loadAllProfilePairedDevices()); } catch {}
+  // Tell the server which operator is active so new pairings get stamped
+  // with the right profileCallsign for auto-switch-on-connect.
+  try { remoteServer.setCurrentOperatorCallsign(settings.activeProfile || ''); } catch {}
   // Persistent share-link store. Operator-created links (Settings →
   // Remote Access → Share Access) outlive desktop restarts so a link
   // emailed Monday still works after a Tuesday reboot. setPendingPairLinks
@@ -6295,8 +7850,35 @@ function connectRemote() {
   // When the server adds or revokes a device, persist the new list.
   remoteServer.on('paired-devices-changed', () => {
     try {
-      settings.pairedDevices = remoteServer.exportPairedDevices();
+      const allDevices = remoteServer.exportPairedDevices();
+      const activeCall = String((settings && settings.activeProfile) || '').toUpperCase();
+
+      // Group by profileCallsign; unstamped legacy devices fall back to active profile
+      const byProfile = {};
+      for (const dev of allDevices) {
+        const p = String(dev.profileCallsign || activeCall || '').toUpperCase();
+        if (!byProfile[p]) byProfile[p] = [];
+        byProfile[p].push(dev);
+      }
+
+      // Save current profile's devices through the normal settings path
+      settings.pairedDevices = byProfile[activeCall] || [];
       saveSettings(settings);
+
+      // Save other profiles' devices directly to their profile settings files
+      for (const [call, devices] of Object.entries(byProfile)) {
+        if (call && call !== activeCall && fs.existsSync(profileDir(call))) {
+          try {
+            const pPath = profileSettingsPath(call);
+            const pSettings = _readJsonSafe(pPath, {});
+            pSettings.pairedDevices = devices;
+            _writeJsonAtomic(pPath, pSettings);
+          } catch (err) {
+            console.error('[multi-op] paired-devices save failed for', call, err.message);
+          }
+        }
+      }
+
       if (win && !win.isDestroyed()) {
         win.webContents.send('echocat-paired-devices', remoteServer.listPairedDevices());
       }
@@ -6376,10 +7958,32 @@ function connectRemote() {
   });
 
   remoteServer.on('ptt', ({ state }) => {
+    // RS-BA1 streaming voice TX: start/stop the ring-buffer pump when the phone
+    // keys/unkeys. Only when the active audio source is the Icom network rig.
+    if (settings.audioSource === 'icom-network') {
+      if (state) {
+        if (_icomNetworkTransport && _icomNetworkTransport.txReady &&
+            !_icomNetworkTransport.voiceTxActive) {
+          try {
+            _rsba1TxChunkCount = 0;       // reset per-PTT so "chunk #1" fires on every key-down
+            _rsba1TxLastPeakReport = 0;
+            _icomNetworkTransport.startVoiceTx();
+            sendCatLog('[Icom-Network-Audio] Voice TX started (ECHOCAT phone PTT)');
+          } catch (e) {
+            sendCatLog('[Icom-Network-Audio] Voice TX start failed: ' + e.message);
+          }
+        }
+      } else {
+        if (_icomNetworkTransport && _icomNetworkTransport.voiceTxActive) {
+          _icomNetworkTransport.stopVoiceTx();
+          sendCatLog('[Icom-Network-Audio] Voice TX stopped (ECHOCAT phone PTT release)');
+        }
+      }
+    }
     handleRemotePtt(state);
   });
 
-  remoteServer.on('client-connected', () => {
+  remoteServer.on('client-connected', ({ deviceId, profileCallsign } = {}) => {
     // Cancel any pending teardown — the phone came back inside the
     // grace window, so the engine kept running and we're whole.
     if (_clientDisconnectGraceTimer) {
@@ -6488,6 +8092,39 @@ function connectRemote() {
     if (win && !win.isDestroyed()) {
       win.webContents.send('remote-status', { connected: true });
     }
+
+    // ── Auto-switch profile on phone connect ─────────────────────────
+    // If the connecting phone's device record has a profileCallsign that
+    // differs from the currently-active profile, automatically switch to
+    // that operator's profile so they get their own callsign, grid,
+    // logbook and settings without touching the Mac.
+    //
+    // Guard: only switch if PTT is not active (don't interrupt a TX),
+    // the target profile exists on disk, and a switch isn't already
+    // in progress. The app restarts in ~2s; the phone sees a brief
+    // disconnect then reconnects automatically to the correct profile.
+    const targetProfile = profileCallsign ? String(profileCallsign).toUpperCase() : '';
+    const currentProfile = String((settings && settings.activeProfile) || '').toUpperCase();
+    if (targetProfile && targetProfile !== currentProfile && !_profileSwitchRelaunchPending) {
+      if (!fs.existsSync(profileDir(targetProfile))) {
+        sendCatLog(`[multi-op] Auto-switch requested for ${targetProfile} but no profile found on disk`);
+      } else if (remoteServer._pttActive) {
+        sendCatLog(`[multi-op] Auto-switch to ${targetProfile} deferred — PTT active on ${currentProfile || '?'}`);
+      } else {
+        sendCatLog(`[multi-op] ECHOCAT device connect: auto-switching ${currentProfile || '?'} → ${targetProfile} (deviceId=${deviceId || '?'})`);
+        const r = switchProfile(targetProfile);
+        if (r.ok && r.restartRequired) {
+          setImmediate(() => {
+            prepareProfileSwitchRelaunch(currentProfile, targetProfile)
+              .catch((err) => {
+                try { appendIcomNetworkDiagnostic(`[multi-op] auto-switch cleanup error: ${err.message || err}`); } catch {}
+              })
+              .finally(() => { app.relaunch(); app.exit(0); });
+          });
+        }
+      }
+    }
+    // ─────────────────────────────────────────────────────────────────
   });
 
   remoteServer.on('client-disconnected', () => {
@@ -8024,6 +9661,8 @@ function connectRemote() {
   });
 
   remoteServer.on('jtcat-halt-tx', () => {
+    clearJtcatTxFailsafe();
+    clearJtcatIcomHardRelease();
     if (jtcatManager) {
       for (const id of jtcatManager.sliceIds) {
         const eng = jtcatManager.getEngine(id);
@@ -8037,6 +9676,8 @@ function connectRemote() {
     }
     remoteJtcatQso = null;
     remoteJtcatBroadcastQso();
+    if (_icomNetworkTransport) { try { _icomNetworkTransport.cancelTx(); } catch {} }
+    if (smartSdrAudio) { try { smartSdrAudio.cancelTx(); } catch {} }
     handleRemotePtt(false);
   });
 
@@ -8106,6 +9747,7 @@ function connectRemote() {
     if (win && !win.isDestroyed()) win.webContents.send('jtcat-set-rx-gain', value);
   });
   remoteServer.on('jtcat-tx-gain', ({ value }) => {
+    setJtcatDirectTxGainLevel(value);
     if (win && !win.isDestroyed()) win.webContents.send('jtcat-set-tx-gain', value);
   });
 
@@ -8220,25 +9862,16 @@ function connectRemote() {
   });
 
   remoteServer.on('sstv-get-gallery', ({ limit, offset, requestId }) => {
-    ensureSstvGalleryDir();
     try {
-      const files = fs.readdirSync(SSTV_GALLERY_DIR)
+      const galleryDir = ensureSstvGalleryDir();
+      const files = fs.readdirSync(galleryDir)
         .filter(f => f.endsWith('.png'))
         .sort((a, b) => b.localeCompare(a));
       const total = files.length;
       const slice = files.slice(offset || 0, (offset || 0) + (limit || 10));
       const images = slice.map(f => {
-        const filePath = path.join(SSTV_GALLERY_DIR, f);
-        const stat = fs.statSync(filePath);
-        const data = fs.readFileSync(filePath);
-        const parts = f.replace('.png', '').split('_');
-        return {
-          filename: f,
-          dataUrl: 'data:image/png;base64,' + data.toString('base64'),
-          mode: parts[1] || '',
-          timestamp: stat.mtimeMs,
-        };
-      });
+        return sstvGalleryRecordFromFile(path.join(galleryDir, f));
+      }).filter(Boolean);
       remoteServer.sendSstvGallery(images, requestId, total);
     } catch (err) {
       console.error('[SSTV] Gallery fetch for ECHOCAT error:', err.message);
@@ -10978,7 +12611,7 @@ function createWindow() {
   win = new BrowserWindow({
     width: defaultW,
     height: defaultH,
-    title: `POTACAT - v${require('./package.json').version}`,
+    title: `POTACAT - v${getAppDisplayVersion()}`,
     ...(isMac ? { titleBarStyle: 'hiddenInset' } : { frame: false }),
     icon: getIconPath(),
     show: false,
@@ -12239,7 +13872,7 @@ function sendTelemetry(sessionSeconds) {
   const https = require('https');
   const payload = JSON.stringify({
     id: settings.telemetryId,
-    version: require('./package.json').version,
+    version: getAppDisplayVersion(),
     os: process.platform,
     sessionSeconds: sessionSeconds || 0,
     active: sessionSeconds === 0 ? true : isUserActive(), // launch ping always active
@@ -12503,6 +14136,10 @@ function tuneRadio(freqKhz, mode, brng, { clearXit } = {}) {
   }
   _lastTuneFreq = freqHz;
   _lastTuneTime = now;
+  if (settings.audioSource === 'icom-network' && settings.catTarget && settings.catTarget.type === 'icom-network') {
+    resetIcomNetworkJtcatUiBuffer();
+    resetIcomNetworkRxPacer(`CAT tune ${freqHz}Hz`);
+  }
 
   // Auto-tune KiwiSDR WebSDR to follow
   if (kiwiActive && kiwiClient && kiwiClient.connected && freqHz > 100000) {
@@ -13110,6 +14747,7 @@ app.whenReady().then(() => {
       console.error('[multi-op] migration failed:', err.message);
     }
   }
+  migrateLegacyCloudTunnelConfig(settings);
   logStartupStage('settings loaded');
   if (settings.colorblindMode) {
     setSmartSdrColorblind(true);
@@ -13149,7 +14787,7 @@ app.whenReady().then(() => {
       }
     }, 1000);
   }
-  if (!settings.enableWsjtx) connectCat();
+  if (!settings.enableWsjtx) connectCatWithStartupDelay();
   if (settings.enableCluster) connectCluster();
   if (settings.enableCwSpots) connectCwSpots();
   // RBN auto-connects when myCallsign is set — passively collected so the
@@ -13271,6 +14909,7 @@ app.whenReady().then(() => {
     const { safeStorage } = require('electron');
     cloudTunnel = new CloudTunnelManager({
       userDataPath: app.getPath('userData'),
+      configPath: profileCloudTunnelPath(settings.activeProfile || settings.myCallsign),
       getCloudSync: () => (cloudIpc ? cloudIpc.getCloudSync() : null),
       getCloudflaredPath: resolveCloudflaredPath,
       log: (msg) => sendCatLog(msg),
@@ -14956,6 +16595,14 @@ app.whenReady().then(() => {
       if (!sstvPopoutWin || sstvPopoutWin.isDestroyed()) {
         openSstvPopout();
       }
+      if (settings.audioSource === 'icom-network' &&
+          !(ICOM_NETWORK_TX_AUDIO_ENABLED && _icomNetworkTransport && _icomNetworkTransport.txReady)) {
+        sendCatLog('[SSTV] Icom Network TX blocked before PTT: RS-BA1 TX audio stream is not ready. Reconnect Icom Network / RS-BA1 or use a local/USB audio source for this transmit.');
+        if (remoteServer && remoteServer.hasClient()) {
+          remoteServer.broadcastSstvTxStatus({ state: autoSstvActive ? 'auto-rx' : 'rx' });
+        }
+        return;
+      }
       // Key PTT
       handleRemotePtt(true);
 
@@ -14990,13 +16637,13 @@ app.whenReady().then(() => {
         }
       }
 
-      // Flex Direct (SmartSDR Direct): there's no Windows DAX TX device for
-      // the pop-out's Web Audio to play into, so the radio would key but
-      // transmit silence. Route the encoded SSTV audio to the radio over
-      // VITA-49 dax_tx instead — the same path FT8/voice use. The pop-out
+      // Direct radio TX paths: if there is no local/virtual TX audio device,
+      // the pop-out's Web Audio would key the radio but transmit silence.
+      // Route encoded SSTV audio straight to the radio instead. The pop-out
       // still shows the TX progress bar but does NOT play audio (daxTx flag).
       // K3SBP 2026-05-28.
       const useDaxTx = settings.audioSource === 'smartsdr' && smartSdrAudio && smartSdrAudio.txReady;
+      const useIcomNetworkTx = settings.audioSource === 'icom-network' && ICOM_NETWORK_TX_AUDIO_ENABLED && _icomNetworkTransport && _icomNetworkTransport.txReady;
       const delay = (!sstvPopoutWin || sstvPopoutWin.isDestroyed()) ? 1500 : 200;
       setTimeout(() => {
         if (useDaxTx) {
@@ -15012,7 +16659,7 @@ app.whenReady().then(() => {
           }
           sendCatLog(`[SSTV] TX via Flex Direct dax_tx — ${outDurSec.toFixed(0)}s (${dn.length} samples @12k)`);
           if (sstvPopoutWin && !sstvPopoutWin.isDestroyed()) {
-            sstvPopoutWin.webContents.send('sstv-tx-audio', { samples: [], durationSec: outDurSec, daxTx: true });
+            sstvPopoutWin.webContents.send('sstv-tx-audio', { samples: [], durationSec: outDurSec, daxTx: true, directTxLabel: 'Flex Direct' });
           }
           smartSdrAudio.sendTxAudio(dn, 500)
             .then(() => {
@@ -15035,6 +16682,47 @@ app.whenReady().then(() => {
               // Same banner-clear on failure — leaving mobile stuck
               // on TRANSMITTING after an error would be worse than
               // dropping back to RX without a notification.
+              if (remoteServer && remoteServer.hasClient()) {
+                remoteServer.broadcastSstvTxStatus({
+                  state: autoSstvActive ? 'auto-rx' : 'rx',
+                });
+              }
+            });
+        } else if (useIcomNetworkTx) {
+          const sstvTxGain = clampNumber(settings.sstvTxGain, 0, 1, 0.5);
+          const networkTxGain = getIcomNetworkTxGain();
+          // peakLimit=1.0: SSTV tones encode information in precise frequency ratios;
+          // hard clipping at 0.95 introduces harmonic distortion that corrupts the
+          // decoder at the receiving end. Apply gain only, no ceiling clipping.
+          const txAudio = conditionDirectTxAudio(outSamples, sstvTxGain * (networkTxGain / DEFAULT_ICOM_NETWORK_TX_GAIN), 1.0);
+          sendCatLog(`[SSTV] TX via Icom Network RS-BA1 audio — ${outDurSec.toFixed(0)}s (${outSamples.length} samples @48k, networkTxGain=${Math.round(networkTxGain * 100)}%); ${formatDirectTxAudioStats(txAudio)}`);
+          // Abort before PTT if the encoder produced a silent waveform.
+          if (txAudio.outputPeak < 0.01) {
+            sendCatLog(`[SSTV] TX aborted: conditioned audio peak ${txAudio.outputPeak.toFixed(4)} is too low (encoder produced silent waveform?)`);
+            handleRemotePtt(false);
+            return;
+          }
+          if (sstvPopoutWin && !sstvPopoutWin.isDestroyed()) {
+            sstvPopoutWin.webContents.send('sstv-tx-audio', { samples: [], durationSec: outDurSec, daxTx: true, directTxLabel: 'Icom Network' });
+          }
+          _icomNetworkTransport.sendTxAudio(txAudio.samples, {
+            offsetMs: 0,
+            inputSampleRate: SSTV_SAMPLE_RATE,
+            startDelayMs: 100, // 200ms (tune delay) was longer than needed; 100ms is enough to prime the radio buffer before VIS header starts
+            tailSilenceMs: 200,
+          })
+            .then(() => {
+              handleRemotePtt(false);
+              sendCatLog('[SSTV] TX complete (Icom Network)');
+              if (remoteServer && remoteServer.hasClient()) {
+                remoteServer.broadcastSstvTxStatus({
+                  state: autoSstvActive ? 'auto-rx' : 'rx',
+                });
+              }
+            })
+            .catch((err) => {
+              handleRemotePtt(false);
+              sendCatLog(`[SSTV] Icom Network TX failed: ${err.message}`);
               if (remoteServer && remoteServer.hasClient()) {
                 remoteServer.broadcastSstvTxStatus({
                   state: autoSstvActive ? 'auto-rx' : 'rx',
@@ -15089,7 +16777,7 @@ app.whenReady().then(() => {
       _sstvLastActivityMs = Date.now();
       applySstvPostProcess(data);
       // Save to gallery
-      saveSstvImage(data);
+      const saved = saveSstvImage(data);
       // Send to popout
       if (sstvPopoutWin && !sstvPopoutWin.isDestroyed()) {
         sstvPopoutWin.webContents.send('sstv-rx-image', {
@@ -15097,6 +16785,7 @@ app.whenReady().then(() => {
           width: data.width,
           height: data.height,
           mode: data.mode,
+          saved,
         });
       }
       // Send to ECHOCAT phone
@@ -15236,11 +16925,51 @@ app.whenReady().then(() => {
     }
   }
 
+  function sanitizeSstvFilenamePart(value, fallback) {
+    const s = String(value || fallback || '').trim().replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
+    return s || fallback || 'sstv';
+  }
+
+  function sstvGalleryRecordFromFile(filePath) {
+    try {
+      const stat = fs.statSync(filePath);
+      const filename = path.basename(filePath);
+      const png = fs.readFileSync(filePath);
+      const img = nativeImage.createFromBuffer(png);
+      const size = img.getSize();
+      let meta = {};
+      const metaPath = filePath.replace(/\.png$/i, '.json');
+      if (fs.existsSync(metaPath)) {
+        try { meta = JSON.parse(fs.readFileSync(metaPath, 'utf-8')); } catch { meta = {}; }
+      }
+      const parts = filename.replace(/\.png$/i, '').split('_');
+      return {
+        filename,
+        filePath,
+        dataUrl: 'data:image/png;base64,' + png.toString('base64'),
+        mode: meta.mode || parts[1] || '',
+        timestamp: meta.timestamp || stat.mtimeMs,
+        width: meta.width || size.width || 320,
+        height: meta.height || size.height || 256,
+        freqHz: meta.freqHz || null,
+        freqKhz: meta.freqKhz || null,
+        callsign: meta.callsign || '',
+      };
+    } catch (err) {
+      console.error('[SSTV] Gallery record error:', err.message);
+      return null;
+    }
+  }
+
   function saveSstvImage(data) {
     try {
-      ensureSstvGalleryDir();
+      const galleryDir = ensureSstvGalleryDir();
       const ts = new Date().toISOString().replace(/[:.]/g, '-').replace('T', '_').slice(0, 19);
-      const filename = `sstv_${data.mode}_${ts}.png`;
+      const modePart = sanitizeSstvFilenamePart(data.mode, 'unknown');
+      const freqPart = _currentFreqHz ? `${Math.round(_currentFreqHz / 1000)}kHz` : '';
+      const callPart = sanitizeSstvFilenamePart(settings.myCallsign || '', '');
+      const pieces = ['sstv', modePart, freqPart, callPart, ts].filter(Boolean);
+      const filename = `${pieces.join('_')}.png`;
       const { nativeImage } = require('electron');
       // ImageData is RGBA, nativeImage expects BGRA — convert
       const rgba = new Uint8ClampedArray(data.imageData);
@@ -15252,10 +16981,27 @@ app.whenReady().then(() => {
         bgra[i + 3] = rgba[i + 3]; // A
       }
       const img = nativeImage.createFromBitmap(bgra, { width: data.width, height: data.height });
-      fs.writeFileSync(path.join(SSTV_GALLERY_DIR, filename), img.toPNG());
-      console.log('[SSTV] Saved decoded image:', filename);
+      const filePath = path.join(galleryDir, filename);
+      fs.writeFileSync(filePath, img.toPNG());
+      const meta = {
+        filename,
+        filePath,
+        mode: data.mode,
+        width: data.width,
+        height: data.height,
+        timestamp: Date.now(),
+        isoTime: new Date().toISOString(),
+        freqHz: _currentFreqHz || null,
+        freqKhz: _currentFreqHz ? Math.round(_currentFreqHz / 1000) : null,
+        callsign: settings.myCallsign || '',
+        postProcessed: settings.sstvPostProcess !== false,
+      };
+      fs.writeFileSync(filePath.replace(/\.png$/i, '.json'), JSON.stringify(meta, null, 2), 'utf-8');
+      console.log('[SSTV] Saved decoded image:', filePath);
+      return sstvGalleryRecordFromFile(filePath);
     } catch (err) {
       console.error('[SSTV] Save image error:', err.message);
+      return null;
     }
   }
 
@@ -15269,6 +17015,7 @@ app.whenReady().then(() => {
     // every decode into noise. Mirror the sstv-audio guards exactly.
     if (settings.audioSource === 'smartsdr' && smartSdrAudio) return;
     if (settings.catTarget && settings.catTarget.type === 'k4-network' && cat && cat.connected) return;
+    if (settings.audioSource === 'icom-network' && settings.catTarget && settings.catTarget.type === 'icom-network' && cat && cat.connected) return;
     if (sstvEngine) sstvEngine.setSampleRate(rate);
     console.log('[SSTV] Audio sample rate set to ' + rate + ' Hz');
   });
@@ -15281,6 +17028,8 @@ app.whenReady().then(() => {
     if (settings.audioSource === 'smartsdr' && smartSdrAudio) return;
     // K4 network: SSTV is fed by handleK4AudioFrame's 4x upsample.
     if (settings.catTarget && settings.catTarget.type === 'k4-network' && cat && cat.connected) return;
+    // Icom Network: SSTV is fed from RS-BA1 RX audio frames in main.
+    if (settings.audioSource === 'icom-network' && settings.catTarget && settings.catTarget.type === 'icom-network' && cat && cat.connected) return;
     if (_sstvFeedPaused) return; // circuit breaker — see flag definition
     let samples;
     if (buf instanceof Float32Array) samples = buf;
@@ -15323,21 +17072,15 @@ app.whenReady().then(() => {
   });
 
   ipcMain.handle('sstv-get-gallery', async () => {
-    ensureSstvGalleryDir();
     try {
-      const files = fs.readdirSync(SSTV_GALLERY_DIR)
+      const galleryDir = ensureSstvGalleryDir();
+      const files = fs.readdirSync(galleryDir)
         .filter(f => f.endsWith('.png'))
         .sort((a, b) => b.localeCompare(a)); // newest first
       const results = [];
       for (const f of files.slice(0, 50)) { // limit to 50 most recent
-        const filePath = path.join(SSTV_GALLERY_DIR, f);
-        const stat = fs.statSync(filePath);
-        const data = fs.readFileSync(filePath);
-        const dataUrl = 'data:image/png;base64,' + data.toString('base64');
-        // Parse mode from filename: sstv_MODE_DATE.png
-        const parts = f.replace('.png', '').split('_');
-        const mode = parts[1] || '';
-        results.push({ filename: f, dataUrl, mode, timestamp: stat.mtimeMs, width: 320, height: 256 });
+        const rec = sstvGalleryRecordFromFile(path.join(galleryDir, f));
+        if (rec) results.push(rec);
       }
       return results;
     } catch (err) {
@@ -15348,8 +17091,11 @@ app.whenReady().then(() => {
 
   ipcMain.handle('sstv-delete-image', async (_e, filename) => {
     try {
-      const filePath = path.join(SSTV_GALLERY_DIR, path.basename(filename));
+      const galleryDir = ensureSstvGalleryDir();
+      const filePath = path.join(galleryDir, path.basename(filename));
       if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+      const metaPath = filePath.replace(/\.png$/i, '.json');
+      if (fs.existsSync(metaPath)) fs.unlinkSync(metaPath);
       return true;
     } catch { return false; }
   });
@@ -15371,8 +17117,8 @@ app.whenReady().then(() => {
   });
 
   ipcMain.on('sstv-open-gallery-folder', () => {
-    ensureSstvGalleryDir();
-    require('electron').shell.openPath(SSTV_GALLERY_DIR);
+    const galleryDir = ensureSstvGalleryDir();
+    require('electron').shell.openPath(galleryDir);
   });
 
   // SSTV pop-out window
@@ -15476,12 +17222,13 @@ app.whenReady().then(() => {
 
     sstvManager.on('rx-image', (data) => {
       applySstvPostProcess(data);
-      saveSstvImage(data);
+      const saved = saveSstvImage(data);
       if (sstvPopoutWin && !sstvPopoutWin.isDestroyed()) {
         sstvPopoutWin.webContents.send('sstv-rx-image', {
           imageData: Array.from(data.imageData),
           width: data.width, height: data.height,
           mode: data.mode, sliceId: data.sliceId,
+          saved,
         });
       }
       if (remoteServer && remoteServer.hasClient()) {
@@ -16517,7 +18264,7 @@ app.whenReady().then(() => {
   ipcMain.on('refresh', () => { markUserActive(); refreshSpots(); });
 
   ipcMain.on('app-relaunch', () => { app.relaunch(); app.exit(0); });
-  ipcMain.handle('get-settings', () => ({ ...settings, appVersion: require('./package.json').version }));
+  ipcMain.handle('get-settings', () => ({ ...settings, appVersion: getAppDisplayVersion() }));
 
   // Manual refresh for one watchlist group's Ham2K PoLo URL. Renderer
   // calls this from the Settings dialog's "Refresh" button so the user
@@ -17317,13 +19064,19 @@ app.whenReady().then(() => {
   ipcMain.handle('profiles-add', (_e, callsign) => addProfile(callsign));
   ipcMain.handle('profiles-switch', (_e, callsign) => {
     const r = switchProfile(callsign);
-    if (r.ok) {
+    if (r.ok && r.restartRequired) {
       // Restart cleanly so every cached subsystem rebinds to the new
       // operator's settings. setImmediate gives the IPC response time
       // to land in the renderer before the window goes away.
       setImmediate(() => {
-        app.relaunch();
-        app.exit(0);
+        prepareProfileSwitchRelaunch(r.previousCallsign, r.callsign)
+          .catch((err) => {
+            try { appendIcomNetworkDiagnostic(`[multi-op] profile switch cleanup error: ${err.message || err}`); } catch {}
+          })
+          .finally(() => {
+            app.relaunch();
+            app.exit(0);
+          });
       });
     }
     return r;
@@ -18040,6 +19793,9 @@ app.whenReady().then(() => {
           remoteAudioWin.webContents.send('smartsdr-audio-fallback');
         }
       }
+      if (settings.catTarget && settings.catTarget.type === 'icom-network') {
+        connectCat();
+      }
     }
 
     // Reconnect TCI if settings changed
@@ -18338,6 +20094,21 @@ app.whenReady().then(() => {
     return path.join(app.getPath('userData'), 'potacat_qso_log.adi');
   });
 
+  ipcMain.handle('get-default-sstv-gallery-path', () => {
+    return defaultSstvGalleryDir();
+  });
+
+  ipcMain.handle('choose-sstv-gallery-folder', async (_e, currentPath) => {
+    const defaultPath = currentPath || getSstvGalleryDir();
+    const result = await dialog.showOpenDialog(win, {
+      title: 'Choose SSTV Received Images Folder',
+      defaultPath,
+      properties: ['openDirectory', 'createDirectory'],
+    });
+    if (result.canceled || !result.filePaths.length) return null;
+    return result.filePaths[0];
+  });
+
   // Generic file picker for the advanced ECHOCAT settings (TLS
   // cert + key path inputs). Open dialog only — these are existing
   // files the user manages outside POTACAT.
@@ -18437,7 +20208,10 @@ app.whenReady().then(() => {
     const { SerialPort } = require('serialport');
 
     // Temporarily disconnect live CAT + kill rigctld to release the serial port
-    if (cat) cat.disconnect();
+    if (cat) {
+      await restoreIcomNetworkDataMod('serial CAT test');
+      cat.disconnect();
+    }
     killRigctld();
 
     // Wait for OS to fully release the serial port
@@ -18519,7 +20293,10 @@ app.whenReady().then(() => {
     const { SerialPort } = require('serialport');
 
     // Temporarily disconnect live CAT to release the serial port
-    if (cat) cat.disconnect();
+    if (cat) {
+      await restoreIcomNetworkDataMod('Icom CI-V test');
+      cat.disconnect();
+    }
 
     await new Promise((r) => setTimeout(r, 500));
 
@@ -18602,6 +20379,197 @@ app.whenReady().then(() => {
 
       port.open((err) => {
         if (err && !settled) { settled = true; clearTimeout(timeout); resolve({ success: false, error: err.message }); }
+      });
+    });
+  });
+
+  ipcMain.handle('test-civ-tcp', async (_e, config) => {
+    const { host, port, civAddress } = config || {};
+
+    // Temporarily disconnect live CAT to avoid two clients driving the rig.
+    if (cat) {
+      await restoreIcomNetworkDataMod('CI-V TCP test');
+      cat.disconnect();
+    }
+    await new Promise((r) => setTimeout(r, 500));
+
+    return new Promise((resolve) => {
+      let settled = false;
+      const transport = new TcpTransport();
+      const model = { brand: 'Icom', protocol: 'civ', civAddr: civAddress || 0x94, caps: {}, cw: {} };
+      const codec = new CivCodec(model, (data) => transport.write(data));
+
+      const finish = (result) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        try { transport.disconnect(); } catch {}
+        resolve(result);
+      };
+
+      const timeout = setTimeout(() => {
+        finish({ success: false, error: 'No CI-V response. Check host, TCP port, CI-V address, and that this endpoint is a raw CI-V TCP bridge.' });
+      }, 6000);
+
+      transport.on('data', (chunk) => codec.onData(chunk));
+      transport.on('connect', () => {
+        setTimeout(() => codec.getFrequency(), 100);
+        setTimeout(() => { if (!settled) codec.getFrequency(); }, 1500);
+      });
+      transport.on('error', (err) => {
+        finish({ success: false, error: err.message || String(err) });
+      });
+      codec.on('frequency', (hz) => {
+        finish({ success: true, frequency: (hz / 1e6).toFixed(6) });
+      });
+      codec.on('error', (err) => {
+        finish({ success: false, error: err.message || 'CI-V NAK' });
+      });
+
+      transport.connect({
+        host: String(host || '').trim() || '127.0.0.1',
+        port: parseInt(port, 10) || 50001,
+      });
+    });
+  });
+
+  ipcMain.handle('test-icom-network', async (_e, config) => {
+    const { host, controlPort, civPort, username, password, civAddress } = config || {};
+
+    if (!String(host || '').trim()) {
+      return { success: false, error: 'Host/IP is required.' };
+    }
+
+    // Temporarily disconnect live CAT to avoid two clients driving the rig.
+    if (cat) {
+      await restoreIcomNetworkDataMod('Icom Network test');
+      cat.disconnect();
+    }
+    await new Promise((r) => setTimeout(r, 500));
+
+    return new Promise((resolve) => {
+      let settled = false;
+      let civStreamReady = false;
+      let activeProbeAddr = civAddress || 0x94;
+      const probeTimers = [];
+      const transport = new RsBa1Transport();
+      const model = { brand: 'Icom', protocol: 'civ', civAddr: civAddress || 0x94, caps: {}, cw: {} };
+      const codec = new CivCodec(model, (data) => transport.write(data));
+      const logs = [];
+
+      const uniq = (items) => {
+        const seen = new Set();
+        return items.filter((item) => {
+          const n = Number(item);
+          if (!Number.isFinite(n) || n < 0 || n > 0xff || seen.has(n)) return false;
+          seen.add(n);
+          return true;
+        });
+      };
+      const probeAddrs = uniq([
+        civAddress || 0x94,
+        0x00, // CI-V broadcast/default probe.
+        0x98, // IC-7610
+        0x94, // IC-7300
+        0xB6, // IC-7300 MK II
+        0xA4, // IC-705
+        0xA2, // IC-9700
+        0x8E, // IC-7851
+        0x96, // IC-7850
+        0x88, // IC-7100
+        0x7A, // IC-7200
+        0x76, // IC-9100
+      ]);
+
+      const recordLog = (msg) => {
+        if (!msg) return;
+        logs.push(String(msg));
+        if (logs.length > 40) logs.shift();
+      };
+
+      const failureForError = (err) => {
+        const code = err && err.code;
+        let message = (err && err.message) || String(err || 'unknown error');
+        if (code === 'RSBA1_NO_IAMHERE') {
+          message += ' Try the radio numeric IPv4 address instead of the hostname, fully quit any other POTACAT/RS-BA1/wfview/USB-CAT controller that may be occupying the radio, confirm Network Control/RS-BA1 is enabled on the radio, confirm UDP control port 50001, and make sure macOS/Windows firewall is not blocking the UDP reply. Credentials are not being checked yet.';
+        } else if (code === 'RSBA1_DNS_FAILED') {
+          message += ' Try entering the radio numeric IPv4 address directly.';
+        } else if (code === 'RSBA1_NO_CIV_IAMHERE') {
+          message += ' Login worked, but the CI-V UDP stream did not open. Check the radio CI-V/network data port settings or try setting the CI-V port explicitly.';
+        }
+        const tail = logs.slice(-12);
+        if (code && String(code).startsWith('RSBA1_') && logs.length) {
+          const head = logs.slice(0, 8);
+          const diagnosticLines = head.length + tail.length < logs.length
+            ? [...head, '...', ...tail]
+            : logs.slice();
+          message += `\nDiagnostics:\n${diagnosticLines.join('\n')}`;
+        }
+        return { success: false, error: message, code: code || null, logs: tail };
+      };
+
+      const finish = (result) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        probeTimers.forEach((t) => clearTimeout(t));
+        try { transport.disconnect(); } catch {}
+        resolve(result);
+      };
+
+      const timeout = setTimeout(() => {
+        const tail = logs.slice(-12);
+        const tried = probeAddrs.map((addr) => `0x${addr.toString(16).toUpperCase().padStart(2, '0')}`).join(', ');
+        const hint = civStreamReady
+          ? `RS-BA1 connected, but the radio did not answer CI-V frequency probes (${tried}). Check the radio CI-V address, CI-V Transceive setting, and whether Network CI-V allows remote control.`
+          : 'No RS-BA1/CI-V response before the CI-V stream opened. Check Network Control, UDP ports, username/password, and CI-V address.';
+        finish({ success: false, error: hint, logs: tail });
+      }, 22000);
+
+      transport.on('log', recordLog);
+      transport.on('data', (chunk) => codec.onData(chunk));
+      transport.on('connect', () => {
+        civStreamReady = true;
+        const probeStartMs = 1200;
+        const probeIntervalMs = 550;
+        const probeRounds = 2;
+        for (let round = 0; round < probeRounds; round++) {
+          probeAddrs.forEach((addr, idx) => {
+            const offset = (round * probeAddrs.length + idx) * probeIntervalMs;
+            probeTimers.push(setTimeout(() => {
+              if (settled) return;
+              activeProbeAddr = addr;
+              codec.setRadioAddress(addr);
+              recordLog(`[rsba1/test] probing CI-V address 0x${addr.toString(16).toUpperCase().padStart(2, '0')} (round ${round + 1})`);
+              codec.getFrequency();
+            }, probeStartMs + offset));
+          });
+        }
+      });
+      transport.on('error', (err) => {
+        finish(failureForError(err));
+      });
+      codec.on('frequency', (hz, meta = {}) => {
+        const responseAddr = meta.fromAddr != null ? meta.fromAddr : activeProbeAddr;
+        finish({
+          success: true,
+          frequency: (hz / 1e6).toFixed(6),
+          civAddress: responseAddr,
+          probedAddress: activeProbeAddr,
+        });
+      });
+      codec.on('error', (err) => {
+        finish({ success: false, error: err.message || 'CI-V NAK' });
+      });
+
+      transport.connect({
+        host: String(host || '').trim(),
+        controlPort: parseInt(controlPort, 10) || 50001,
+        civPort: parseInt(civPort, 10) || null,
+        username: username || '',
+        password: password || '',
+        compName: 'POTACAT-Test',
+        timeoutMs: 18000,
       });
     });
   });
@@ -18881,6 +20849,8 @@ app.whenReady().then(() => {
   });
   ipcMain.on('jtcat-enable-tx', (_e, enabled) => { if (ft8Engine) ft8Engine._txEnabled = enabled; });
   ipcMain.on('jtcat-halt-tx', () => {
+    clearJtcatTxFailsafe();
+    clearJtcatIcomHardRelease();
     // Halt TX on ALL engines (multi-slice: any engine could be TX'ing)
     if (jtcatManager) {
       for (const id of jtcatManager.sliceIds) {
@@ -18896,13 +20866,19 @@ app.whenReady().then(() => {
       ft8Engine._txEnabled = false;
       if (ft8Engine._txActive) ft8Engine.txComplete();
     }
-    // Halt also kills any active tune
-    if (jtcatTuneState.active) stopJtcatTune();
+	    // Halt also kills any active tune
+	    if (jtcatTuneState.active) stopJtcatTune();
+	    if (smartSdrAudio) { try { smartSdrAudio.cancelTx(); } catch {} }
     // Also clear QSO state
     if (popoutJtcatQso) { popoutJtcatQso = null; popoutBroadcastQso(); }
     if (remoteJtcatQso) { remoteJtcatQso = null; remoteJtcatBroadcastQso(); }
-    handleRemotePtt(false);
-  });
+	    if (settings.audioSource === 'icom-network') {
+	      forceReleaseIcomNetworkTx('JTCAT halt');
+	    } else {
+	      if (_icomNetworkTransport) { try { _icomNetworkTransport.cancelTx(); } catch {} }
+	      handleRemotePtt(false);
+	    }
+	  });
 
   // KD2TJU: WSJT-X-style Tune button — keys PTT and plays a steady tone
   // through the rig USB CODEC for up to 90s, so the user can dial in TX
@@ -18915,6 +20891,7 @@ app.whenReady().then(() => {
   ipcMain.on('jtcat-set-tx-msg', (_e, text) => { if (ft8Engine) ft8Engine.setTxMessage(text); });
   ipcMain.on('jtcat-set-tx-slot', (_e, slot) => { if (ft8Engine) ft8Engine.setTxSlot(slot); });
   ipcMain.on('jtcat-set-tx-gain', (_e, level) => {
+    setJtcatDirectTxGainLevel(level);
     // Relay TX gain from popout to main renderer
     if (win && !win.isDestroyed()) win.webContents.send('jtcat-set-tx-gain', level);
   });
@@ -18988,6 +20965,38 @@ app.whenReady().then(() => {
       _pushK4TxSamples(samples);
     }
   });
+
+  // RS-BA1 voice TX chunks from remote-audio.html (ECHOCAT phone mic → WebRTC
+  // → renderer tap → IPC chunk → here → AudioStream ring buffer → UDP to radio).
+  // Each chunk is a Float32Array of 128 mono samples at 48 kHz (one AudioWorklet
+  // quantum). The renderer only sends while kiwiTxMuted=true (PTT is held), but
+  // main-process also guards at the transport level: pushVoiceChunk() is a no-op
+  // when _voiceTxActive is false. Logging mirrors the DAX TX handler above.
+  let _rsba1TxChunkCount = 0;
+  let _rsba1TxLastPeakReport = 0;
+  ipcMain.on('rsba1-voice-tx-chunk', (_e, buf) => {
+    if (!_icomNetworkTransport || !_icomNetworkTransport.voiceTxActive) return;
+    let samples;
+    if (buf instanceof Float32Array) samples = buf;
+    else if (ArrayBuffer.isView(buf) || buf instanceof ArrayBuffer) samples = new Float32Array(buf);
+    else if (Array.isArray(buf)) samples = new Float32Array(buf);
+    else { try { samples = new Float32Array(Object.values(buf)); } catch { return; } }
+    _rsba1TxChunkCount++;
+    let peak = 0;
+    for (let i = 0; i < samples.length; i++) {
+      const v = Math.abs(samples[i]); if (v > peak) peak = v;
+    }
+    if (peak > _rsba1TxLastPeakReport) _rsba1TxLastPeakReport = peak;
+    // Heartbeat every ~1 s (chunks arrive at ~375/s at 48 kHz / 128 samples)
+    if (_rsba1TxChunkCount === 1 || _rsba1TxChunkCount % 375 === 0) {
+      sendCatLog(`[Icom-Network-Audio] RS-BA1 voice TX chunk #${_rsba1TxChunkCount}: max peak=${_rsba1TxLastPeakReport.toFixed(4)}`);
+      _rsba1TxLastPeakReport = 0;
+    }
+    try { _icomNetworkTransport.pushVoiceChunk(samples); } catch (e) {
+      console.warn('[Icom-Network-Audio] pushVoiceChunk error:', e.message);
+    }
+  });
+
   ipcMain.on('jtcat-log', (_e, msg) => {
     console.log(msg);
     // Also surface in the Verbose CAT log so users diagnosing JTCAT
@@ -19006,6 +21015,8 @@ app.whenReady().then(() => {
     // DAX capture (which on a K4-network setup would just be silence or
     // mis-routed audio anyway) must not double-feed. K3SBP 2026-05-16.
     if (settings.catTarget && settings.catTarget.type === 'k4-network' && cat && cat.connected) return;
+    // Icom Network RX audio follows the same main-process feed pattern.
+    if (settings.audioSource === 'icom-network' && settings.catTarget && settings.catTarget.type === 'icom-network' && cat && cat.connected) return;
     _jtcatAudioDiag++;
     // Ensure buf is a proper array — IPC serialization on macOS can produce
     // objects that Float32Array constructor interprets as length instead of data
@@ -19979,7 +21990,10 @@ function gracefulCleanup() {
   } catch {}
   if (spotTimer) clearInterval(spotTimer);
   if (solarTimer) clearInterval(solarTimer);
-  if (cat) try { cat.disconnect(); } catch {}
+  if (cat) try {
+    restoreIcomNetworkDataMod('app quit');
+    cat.disconnect();
+  } catch {}
   for (const [, entry] of clusterClients) { try { entry.client.disconnect(); } catch {} }
   clusterClients.clear();
   for (const [, c] of cwSpotsClients) { try { c.disconnect(); } catch {} }

--- a/preload.js
+++ b/preload.js
@@ -179,6 +179,8 @@ contextBridge.exposeInMainWorld('api', {
   testHamlib: (config) => ipcRenderer.invoke('test-hamlib', config),
   testSerialCat: (config) => ipcRenderer.invoke('test-serial-cat', config),
   testIcomCiv: (config) => ipcRenderer.invoke('test-icom-civ', config),
+  testCivTcp: (config) => ipcRenderer.invoke('test-civ-tcp', config),
+  testIcomNetwork: (config) => ipcRenderer.invoke('test-icom-network', config),
   connectCat: (target) => ipcRenderer.send('connect-cat', target),
   onCatFrequency: (cb) => ipcRenderer.on('cat-frequency', (_e, hz) => cb(hz)),
   onCatMode: (cb) => ipcRenderer.on('cat-mode', (_e, mode) => cb(mode)),
@@ -378,6 +380,7 @@ contextBridge.exposeInMainWorld('api', {
   jtcatSetAudioLatencyMs: (payload) => ipcRenderer.send('jtcat-set-audio-latency-ms', payload),
   onJtcatAudioLatency: (cb) => ipcRenderer.on('jtcat-audio-latency', (_e, data) => cb(data)),
   jtcatSetHoldTxFreq: (enabled) => ipcRenderer.send('jtcat-set-hold-tx-freq', !!enabled),
+  jtcatSetTxGain: (level) => ipcRenderer.send('jtcat-set-tx-gain', level),
   jtcatEnableTx: (enabled) => ipcRenderer.send('jtcat-enable-tx', enabled),
   jtcatHaltTx: () => ipcRenderer.send('jtcat-halt-tx'),
   jtcatTuneToggle: () => ipcRenderer.send('jtcat-tune-toggle'),
@@ -466,6 +469,7 @@ contextBridge.exposeInMainWorld('api', {
       }
     });
   },
+  setJtcatIpAudioReady: (ready) => ipcRenderer.send('jtcat-ip-audio-ready', { ready: !!ready }),
   // Cloud Sync
   qrzDownloadLogbook: () => ipcRenderer.invoke('qrz-download-logbook'),
   qrzDebugDump: () => ipcRenderer.invoke('qrz-debug-dump'),

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -1765,6 +1765,7 @@ async function populateRadioSection(currentTarget) {
     document.getElementById('set-icom-network-civ-port').value = currentTarget.civPort || '';
     document.getElementById('set-icom-network-username').value = currentTarget.username || '';
     document.getElementById('set-icom-network-password').value = currentTarget.password || '';
+    setIcomNetworkTxGainPct(Math.round(((currentTarget.networkTxGain == null ? 0.72 : currentTarget.networkTxGain) || 0) * 100));
     const inModelSelect = document.getElementById('set-icom-network-model');
     if (inModelSelect && currentTarget.civAddress != null) {
       const hex = '0x' + currentTarget.civAddress.toString(16).toUpperCase();
@@ -1999,6 +2000,28 @@ function describeRigTarget(target) {
   if (target.type === 'icom') {
     return `${target.civModel || 'Icom'} CI-V on ${shortSerialPath(target.path)} @ ${target.baudRate || 115200}`;
   }
+  if (target.type === 'civ-tcp') {
+    const model = target.civModel || 'Icom CI-V';
+    const host = target.host || '127.0.0.1';
+    const port = target.port || 50001;
+    const addr = Number.isFinite(target.civAddress)
+      ? ` CI-V 0x${target.civAddress.toString(16).toUpperCase().padStart(2, '0')}`
+      : '';
+    return `${model} raw CI-V TCP ${host}:${port}${addr}`;
+  }
+  if (target.type === 'icom-network') {
+    const model = target.civModel || 'Icom Network';
+    const host = target.host || '?';
+    const controlPort = target.controlPort || target.port || 50001;
+    const dataPort = target.civPort ? `, CI-V UDP ${target.civPort}` : ', CI-V auto';
+    const addr = Number.isFinite(target.civAddress)
+      ? `, addr 0x${target.civAddress.toString(16).toUpperCase().padStart(2, '0')}`
+      : '';
+    return `${model} RS-BA1 UDP ${host}:${controlPort}${dataPort}${addr}`;
+  }
+  if (target.type === 'k4-network') {
+    return `Elecraft K4 network ${target.host || '127.0.0.1'}:${target.port || 9205}`;
+  }
   if (target.type === 'rigctld') {
     const comPort = target.serialPort || '?';
     const rPort = target.rigctldPort && target.rigctldPort !== 4532 ? ` (port ${target.rigctldPort})` : '';
@@ -2051,7 +2074,11 @@ function renderRigList(rigs, activeRigId) {
     nameEl.textContent = rig.name || 'Unnamed Rig';
     const descEl = document.createElement('div');
     descEl.className = 'rig-item-desc';
-    descEl.textContent = (rig.model ? rig.model + ' \u2014 ' : '') + describeRigTarget(rig.catTarget);
+    const targetDesc = describeRigTarget(rig.catTarget);
+    const modelPrefix = rig.model && !targetDesc.toLowerCase().startsWith(String(rig.model).toLowerCase())
+      ? rig.model + ' \u2014 '
+      : '';
+    descEl.textContent = modelPrefix + targetDesc;
     info.appendChild(nameEl);
     info.appendChild(descEl);
 
@@ -2147,6 +2174,7 @@ function buildCatTargetFromForm() {
       civPort: Number.isFinite(civPortVal) && civPortVal > 0 ? civPortVal : null,
       username: document.getElementById('set-icom-network-username').value || '',
       password: document.getElementById('set-icom-network-password').value || '',
+      networkTxGain: setIcomNetworkTxGainPct(document.getElementById('set-icom-network-tx-gain')?.value) / 100,
       civAddr: parseInt(inModelSelect.value, 16),
       civAddress: parseInt(inModelSelect.value, 16),
       civModel: inModelSelect.options[inModelSelect.selectedIndex].text,
@@ -2176,6 +2204,25 @@ function buildCatTargetFromForm() {
   }
   return null;
 }
+
+function clampIcomNetworkTxGainPct(value) {
+  value = Number(value);
+  if (!Number.isFinite(value)) value = 72;
+  return Math.max(0, Math.min(150, Math.round(value)));
+}
+
+function setIcomNetworkTxGainPct(value) {
+  const pct = clampIcomNetworkTxGainPct(value);
+  const slider = document.getElementById('set-icom-network-tx-gain');
+  const label = document.getElementById('set-icom-network-tx-gain-val');
+  if (slider) slider.value = pct;
+  if (label) label.textContent = pct + '%';
+  return pct;
+}
+
+document.getElementById('set-icom-network-tx-gain')?.addEventListener('input', (e) => {
+  setIcomNetworkTxGainPct(e.target.value);
+});
 
 async function openRigEditor(mode, rigId) {
   rigEditorMode = mode;
@@ -7315,6 +7362,87 @@ document.getElementById('icom-test-btn').addEventListener('click', async () => {
   } catch (err) {
     resultEl.textContent = `Error: ${err.message}`;
     resultEl.className = 'hamlib-test-fail';
+  } finally {
+    btn.disabled = false;
+  }
+});
+
+// Raw CI-V TCP bridge test connection
+document.getElementById('civ-tcp-test-btn')?.addEventListener('click', async () => {
+  const host = (document.getElementById('set-civ-tcp-host').value || '').trim() || '127.0.0.1';
+  const port = parseInt(document.getElementById('set-civ-tcp-port').value, 10) || 50001;
+  const civAddress = parseInt(document.getElementById('set-civ-tcp-model').value, 16);
+  const resultEl = document.getElementById('civ-tcp-test-result');
+  const btn = document.getElementById('civ-tcp-test-btn');
+
+  btn.disabled = true;
+  resultEl.textContent = 'Testing...';
+  resultEl.className = '';
+  resultEl.title = '';
+
+  try {
+    const result = await window.api.testCivTcp({ host, port, civAddress });
+    if (result.success) {
+      resultEl.textContent = `Connected! Freq: ${result.frequency} MHz`;
+      resultEl.className = 'hamlib-test-success';
+    } else {
+      resultEl.textContent = `Failed: ${result.error}`;
+      resultEl.className = 'hamlib-test-fail';
+      resultEl.title = Array.isArray(result.logs) && result.logs.length ? result.logs.join('\n') : '';
+    }
+  } catch (err) {
+    resultEl.textContent = `Error: ${err.message}`;
+    resultEl.className = 'hamlib-test-fail';
+    resultEl.title = '';
+  } finally {
+    btn.disabled = false;
+  }
+});
+
+// Icom Network / RS-BA1 test connection
+document.getElementById('icom-network-test-btn')?.addEventListener('click', async () => {
+  const inModelSelect = document.getElementById('set-icom-network-model');
+  const civPortVal = parseInt(document.getElementById('set-icom-network-civ-port').value, 10);
+  const config = {
+    host: (document.getElementById('set-icom-network-host').value || '').trim(),
+    controlPort: parseInt(document.getElementById('set-icom-network-control-port').value, 10) || 50001,
+    civPort: Number.isFinite(civPortVal) && civPortVal > 0 ? civPortVal : null,
+    username: document.getElementById('set-icom-network-username').value || '',
+    password: document.getElementById('set-icom-network-password').value || '',
+    civAddress: parseInt(inModelSelect.value, 16),
+  };
+  const resultEl = document.getElementById('icom-network-test-result');
+  const btn = document.getElementById('icom-network-test-btn');
+
+  if (!config.host) {
+    resultEl.textContent = 'Enter the radio host/IP first';
+    resultEl.className = 'hamlib-test-fail';
+    return;
+  }
+
+  btn.disabled = true;
+  resultEl.textContent = 'Testing...';
+  resultEl.className = '';
+  resultEl.title = '';
+
+  try {
+    const result = await window.api.testIcomNetwork(config);
+    if (result.success) {
+      const responseAddr = Number.isFinite(result.civAddress) ? ` CI-V: 0x${result.civAddress.toString(16).toUpperCase().padStart(2, '0')}` : '';
+      const probeAddr = Number.isFinite(result.probedAddress) && result.probedAddress !== result.civAddress
+        ? ` (answered probe 0x${result.probedAddress.toString(16).toUpperCase().padStart(2, '0')})`
+        : '';
+      resultEl.textContent = `Connected! Freq: ${result.frequency} MHz${responseAddr}${probeAddr}`;
+      resultEl.className = 'hamlib-test-success';
+    } else {
+      resultEl.textContent = `Failed: ${result.error}`;
+      resultEl.className = 'hamlib-test-fail';
+      resultEl.title = Array.isArray(result.logs) && result.logs.length ? result.logs.join('\n') : '';
+    }
+  } catch (err) {
+    resultEl.textContent = `Error: ${err.message}`;
+    resultEl.className = 'hamlib-test-fail';
+    resultEl.title = '';
   } finally {
     btn.disabled = false;
   }
@@ -12621,7 +12749,9 @@ async function openSettingsDialog(tab) {
   }
   setRemoteCwEnabled.checked = !!s.remoteCwEnabled;
   setRemoteStun.checked = !!s.remoteStun;
-  if (setAudioSource) setAudioSource.value = (s.audioSource === 'smartsdr') ? 'smartsdr' : 'dax';
+  if (setAudioSource) {
+    setAudioSource.value = ['smartsdr', 'icom-network'].includes(s.audioSource) ? s.audioSource : 'dax';
+  }
   // TX EQ — load saved state into the Settings dialog. Live updates go
   // through window.api.setTxEq() so toggling the checkbox / dropdown
   // doesn't require reopening Settings or clicking Save.
@@ -21666,6 +21796,7 @@ var jtcatSpectrumFrame = 0;    // frame counter for throttling spectrum IPC to ~
 var jtcatVita49Ctx = null;
 var jtcatVita49Dest = null;
 var jtcatVita49Node = null; // single AudioWorkletNode — replaces per-frame BufferSource churn
+var jtcatVita49FrameCount = 0;
 
 window.api.onJtcatVita49Audio(function (frame) {
   // Return false so the preload acks immediately when we're not the
@@ -21678,6 +21809,15 @@ window.api.onJtcatVita49Audio(function (frame) {
   // Audio node allocation. The IPC-deserialized typed array may not be
   // a Float32Array; coerce so the worklet sees uniform shape.
   var pcm = (frame.pcm instanceof Float32Array) ? frame.pcm : new Float32Array(frame.pcm);
+  jtcatVita49FrameCount++;
+  if (window.api.jtcatLog && (jtcatVita49FrameCount === 1 || jtcatVita49FrameCount % 200 === 0)) {
+    var peak = 0;
+    for (var i = 0; i < pcm.length; i++) {
+      var v = Math.abs(pcm[i]);
+      if (v > peak) peak = v;
+    }
+    window.api.jtcatLog(`[JTCAT] Synthetic IP audio frame #${jtcatVita49FrameCount}: ${pcm.length} samples, peak=${peak.toFixed(4)}`);
+  }
   jtcatVita49Node.port.postMessage(pcm);
   return true;
 });
@@ -21691,8 +21831,8 @@ async function startJtcatAudio() {
   try {
     var s = await window.api.getSettings();
 
-    if (s.audioSource === 'smartsdr') {
-      // SmartSDR Direct: JTCAT audio is the VITA-49 dax_rx stream that
+    if (s.audioSource === 'smartsdr' || s.audioSource === 'icom-network') {
+      // SmartSDR Direct / Icom Network: JTCAT audio is the PCM stream that
       // main forwards as 'jtcat-vita49-audio' frames — not a Windows
       // audio device. Build a synthetic MediaStream from those frames so
       // everything below this point (createMediaStreamSource, gain,
@@ -21716,16 +21856,25 @@ async function startJtcatAudio() {
         if (window.api.jtcatLog) window.api.jtcatLog('[JTCAT] VITA-49 source worklet load failed: ' + (e.message || e));
         throw e;
       }
+      const vita49SourceOptions = s.audioSource === 'icom-network'
+        ? { sourceRate: 24000, bufferMs: 600, startBufferMs: 150, resumeBufferMs: 200 }
+        : { sourceRate: 24000, bufferMs: 500, startBufferMs: 80, resumeBufferMs: 80 };
       jtcatVita49Node = new AudioWorkletNode(jtcatVita49Ctx, 'jtcat-vita49-source', {
         numberOfInputs: 0,
         numberOfOutputs: 1,
         outputChannelCount: [1],
-        processorOptions: { sourceRate: 24000 },
+        processorOptions: vita49SourceOptions,
       });
+      jtcatVita49FrameCount = 0;
       jtcatVita49Dest = jtcatVita49Ctx.createMediaStreamDestination();
       jtcatVita49Node.connect(jtcatVita49Dest);
       jtcatAudioStream = jtcatVita49Dest.stream;
-      if (window.api.jtcatLog) window.api.jtcatLog('[JTCAT] Audio source: SmartSDR Direct (VITA-49 dax_rx via AudioWorklet)');
+      if (window.api.setJtcatIpAudioReady) window.api.setJtcatIpAudioReady(true);
+      if (window.api.jtcatLog) {
+        const label = s.audioSource === 'icom-network' ? 'Icom Network audio (RS-BA1)' : 'SmartSDR Direct (VITA-49 dax_rx)';
+        const bufferText = s.audioSource === 'icom-network' ? ' with low-latency jitter buffer' : '';
+        window.api.jtcatLog(`[JTCAT] Audio source: ${label} via AudioWorklet${bufferText}`);
+      }
     } else {
       var audioConstraints = {
         channelCount: 1,
@@ -21945,12 +22094,37 @@ var jtcatTxGainLevel = 1.0;
 // and full range at the top. Slider 14% ≈ 0.02 gain, 20% ≈ 0.04 gain.
 function txPwrToGain(pct) { return (pct / 100) * (pct / 100); }
 function gainToTxPwr(gain) { return Math.round(Math.sqrt(gain) * 100); }
+function clampTxPwrPct(pct) {
+  pct = Number(pct);
+  if (!Number.isFinite(pct)) pct = 100;
+  return Math.max(0, Math.min(100, Math.round(pct)));
+}
+function syncJtcatTxGainToMain() {
+  if (window.api && typeof window.api.jtcatSetTxGain === 'function') {
+    window.api.jtcatSetTxGain(jtcatTxGainLevel);
+  }
+}
+function setJtcatTxGainPct(pct, persist) {
+  pct = clampTxPwrPct(pct);
+  jtcatTxGainLevel = txPwrToGain(pct);
+  if (jtcatTxGainSlider) jtcatTxGainSlider.value = pct;
+  if (jtcatTxGainVal) jtcatTxGainVal.textContent = pct + '%';
+  if (persist) {
+    localStorage.setItem('jtcat-tx-gain', pct);
+    localStorage.setItem('jtcat-tx-gain-user-set', '1');
+  }
+  syncJtcatTxGainToMain();
+}
 
 if (jtcatTxGainSlider) {
+  var savedJtcatTxPct = parseInt(localStorage.getItem('jtcat-tx-gain'), 10);
+  var hasUserSavedJtcatTxGain = localStorage.getItem('jtcat-tx-gain-user-set') === '1';
+  var initialJtcatTxPct = hasUserSavedJtcatTxGain && Number.isFinite(savedJtcatTxPct)
+    ? savedJtcatTxPct
+    : parseInt(jtcatTxGainSlider.value, 10);
+  setJtcatTxGainPct(initialJtcatTxPct, false);
   jtcatTxGainSlider.addEventListener('input', function() {
-    var pct = parseInt(jtcatTxGainSlider.value, 10);
-    jtcatTxGainVal.textContent = pct + '%';
-    jtcatTxGainLevel = txPwrToGain(pct);
+    setJtcatTxGainPct(jtcatTxGainSlider.value, true);
   });
 }
 // Accept RX gain from popout or ECHOCAT
@@ -21965,12 +22139,14 @@ window.api.onJtcatSetRxGain(function(level) {
 window.api.onJtcatSetTxGain(function(level) {
   jtcatTxGainLevel = level;
   if (jtcatTxGainSlider) {
-    jtcatTxGainSlider.value = gainToTxPwr(level);
-    jtcatTxGainVal.textContent = gainToTxPwr(level) + '%';
+    var pct = clampTxPwrPct(gainToTxPwr(level));
+    jtcatTxGainSlider.value = pct;
+    if (jtcatTxGainVal) jtcatTxGainVal.textContent = pct + '%';
   }
 });
 
 function stopJtcatAudio() {
+  if (window.api.setJtcatIpAudioReady) window.api.setJtcatIpAudioReady(false);
   if (jtcatMeterAnim) { cancelAnimationFrame(jtcatMeterAnim); jtcatMeterAnim = null; }
   if (waterfallAnimFrame) {
     cancelAnimationFrame(waterfallAnimFrame);
@@ -22002,6 +22178,7 @@ function stopJtcatAudio() {
     jtcatVita49Ctx = null;
   }
   jtcatVita49Dest = null;
+  jtcatVita49FrameCount = 0;
 }
 
 // Restart JTCAT audio after ECHOCAT releases the shared audio device

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -1429,6 +1429,14 @@
           </select>
         </label>
         <span class="help-text" style="margin-bottom:8px;display:block;">Used in N1MM+ RadioInfo UDP broadcast. Set to 2 for a second radio in SO2R setups (FreqEZ, band decoders).</span>
+        <label style="display:block;margin:10px 0 4px;">Audio source for JTCAT / SSTV:
+          <select id="set-audio-source" style="min-width:240px;">
+            <option value="dax">Local audio device / DAX</option>
+            <option value="smartsdr">SmartSDR Direct (no DAX program)</option>
+            <option value="icom-network">Icom Network audio (RS-BA1)</option>
+          </select>
+        </label>
+        <span class="help-text" style="display:block;margin-bottom:8px;">Choose Icom Network audio when the active rig is Icom Network / RS-BA1. POTACAT uses the radio's UDP audio stream for JTCAT/SSTV receive audio and can send JTCAT FT8/FT4 plus SSTV transmit audio directly over RS-BA1.</span>
         <label class="radio-label"><input type="radio" name="radio-type" value="flex" checked> FlexRadio</label>
         <div id="flex-config" class="radio-sub hidden">
           <label>Radio IP:
@@ -1450,13 +1458,6 @@
             </label>
             <span class="help-text" style="display:block;">0 = no limit. Capping reduces audio dropouts on a Flex 6500.</span>
           </div>
-          <label style="display:block;margin-top:10px;">Audio source:
-            <select id="set-audio-source" style="min-width:200px;">
-              <option value="dax">DAX (SmartSDR virtual driver)</option>
-              <option value="smartsdr">SmartSDR Direct (no DAX program)</option>
-            </select>
-          </label>
-          <span class="help-text" style="display:block;">SmartSDR Direct subscribes to Flex audio over UDP and bypasses the DAX program &mdash; useful when DAX gets stuck silent under RDP.</span>
           <details id="flex-advanced" style="margin-top:10px;">
             <summary>Advanced</summary>
             <label style="margin-top:8px;">Legacy SmartSDR CAT slice:
@@ -1558,9 +1559,9 @@
           </div>
           <span class="help-text" style="margin-top:6px;display:block;">For CW paddle keying via ECHOCAT, set your radio menu: SET > Connectors > USB SEND/Keying > USB Keying (CW) = DTR</span>
         </div>
-        <label class="radio-label"><input type="radio" name="radio-type" value="civ-tcp"> Icom CI-V over TCP</label>
+        <label class="radio-label"><input type="radio" name="radio-type" value="civ-tcp"> Raw CI-V TCP bridge</label>
         <div id="civ-tcp-config" class="radio-sub hidden">
-          <span class="help-text" style="font-size:12px;">Raw CI-V frames over TCP. Works with (a) the IC-7300 MK II / IC-705 MK II / IC-7610 MK II native Network CI-V over LAN, or (b) a <code>ser2net</code> / <code>socat</code> bridge on a radio-adjacent box that exposes a USB CI-V port as a TCP listener.</span>
+          <span class="help-text" style="font-size:12px;">Raw CI-V frames over a plain TCP socket. Use this for a <code>ser2net</code> / <code>socat</code> bridge, or for hardware that explicitly exposes raw CI-V as TCP. Native Icom LAN remote control usually uses the Icom Network / RS-BA1 option below.</span>
           <label>Radio Model:
             <select id="set-civ-tcp-model">
               <option value="0x94">IC-7300</option>
@@ -1585,9 +1586,9 @@
             <button type="button" id="civ-tcp-test-btn">Test Connection</button>
             <span id="civ-tcp-test-result" style="font-size:12px;"></span>
           </div>
-          <span class="help-text" style="margin-top:6px;display:block;">IC-7300 MK II default port is <code>50001</code>. For <code>ser2net</code>, whatever TCP port you configured in <code>/etc/ser2net.yaml</code>. CW paddle keying works the same as direct USB CI-V — the codec sends the same CW key command (0x1C 0x01) over the TCP transport.</span>
+          <span class="help-text" style="margin-top:6px;display:block;">For <code>ser2net</code>, use whatever TCP port you configured in <code>/etc/ser2net.yaml</code>. CW paddle keying works the same as direct USB CI-V — the codec sends the same CW key command (0x1C 0x01) over the TCP transport.</span>
         </div>
-        <label class="radio-label"><input type="radio" name="radio-type" value="icom-network"> Icom (Network / RS-BA1) <span style="font-size:10px;color:var(--text-tertiary);">— experimental</span></label>
+        <label class="radio-label"><input type="radio" name="radio-type" value="icom-network"> Icom Network (UDP / RS-BA1) <span style="font-size:10px;color:var(--text-tertiary);">— CAT + RX/TX audio</span></label>
         <div id="icom-network-config" class="radio-sub hidden">
           <span class="help-text" style="font-size:12px;">RS-BA1 protocol over UDP. Connect to (a) <code>wfserver</code> (wfview's headless server) running on a Linux/Mac/Pi adjacent to a USB-attached Icom — typical setup for IC-7300 / IC-7100 / FT-710 — or (b) directly to an IP-native Icom (IC-705, IC-9700, IC-7610, IC-7851, IC-R8600). Username/password come from whatever you set in wfserver's <code>--setup</code>, or in the radio's own <strong>Network User</strong> menu.</span>
           <label>Radio Model:
@@ -1617,7 +1618,17 @@
           <label>Password:
             <input type="password" id="set-icom-network-password" autocomplete="off">
           </label>
-          <span class="help-text" style="margin-top:6px;display:block;">Phase 1: CAT only (frequency, mode, CW text). No audio yet — bridge audio separately if needed (Mumble, virtual cable). For wfserver setup, see <code>WFSERVER.md</code> in the wfview repo.</span>
+          <label>Network TX gain:
+            <div style="display:flex;align-items:center;gap:10px;">
+              <input type="range" id="set-icom-network-tx-gain" min="0" max="150" value="72" style="flex:1;">
+              <span id="set-icom-network-tx-gain-val" style="min-width:44px;text-align:right;">72%</span>
+            </div>
+          </label>
+          <div style="margin-top:6px;display:flex;align-items:center;gap:8px;">
+            <button type="button" id="icom-network-test-btn">Test Connection</button>
+            <span id="icom-network-test-result" style="font-size:12px;"></span>
+          </div>
+          <span class="help-text" style="margin-top:6px;display:block;">CAT plus RS-BA1 receive/transmit audio. With Audio source set to Icom Network audio, POTACAT receives radio audio over UDP for JTCAT/SSTV decoding and can send JTCAT FT8/FT4 audio directly over the radio's RS-BA1 TX stream. Network TX gain scales the IP audio drive before it reaches the radio; use it with the JTCAT TX Pwr slider and the radio's LAN MOD gain to get clean output with little or no ALC.</span>
         </div>
         <label class="radio-label"><input type="radio" name="radio-type" value="hamlib"> Other Rig (Hamlib)</label>
         <div id="hamlib-config" class="radio-sub hidden">

--- a/test/rsba1-transport.test.js
+++ b/test/rsba1-transport.test.js
@@ -1,0 +1,1005 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('assert');
+const dgram = require('dgram');
+const { RsBa1Transport, passcodeBytes, streamIdFromLocalAddress, selectLocalAddressForTarget, resampleMonoFloat32 } = require('../lib/rsba1-transport');
+
+const CONTROL_SIZE = 0x10;
+const PING_SIZE = 0x15;
+const TOKEN_SIZE = 0x40;
+const STATUS_SIZE = 0x50;
+const LOGIN_RESPONSE_SIZE = 0x60;
+const LOGIN_SIZE = 0x80;
+const CONNINFO_SIZE = 0x90;
+const CAPABILITIES_SIZE = 0x42;
+const RADIO_CAP_SIZE = 0x66;
+const CIV_HEADER_SIZE = 0x15;
+const AUDIO_HEADER_SIZE = 0x18;
+const OPENCLOSE_SIZE = 0x16;
+const AUDIO_CODEC_LPCM16_MONO = 0x04;
+const AUDIO_CODEC_LPCM16_STEREO = 0x10;
+
+const TYPE_RETRANSMIT = 0x00;
+const TYPE_AYT = 0x03;
+const TYPE_IAMHERE = 0x04;
+const TYPE_DISCONNECT = 0x05;
+const TYPE_AYR_IAR = 0x06;
+const TYPE_PING = 0x07;
+
+let passed = 0;
+let failed = 0;
+
+async function test(name, fn) {
+  try {
+    await fn();
+    passed++;
+    console.log(`  ok ${name}`);
+  } catch (err) {
+    failed++;
+    console.log(`  FAIL ${name}`);
+    console.log(`    ${err.message}`);
+  }
+}
+
+function buildControl(type, seq, sentid, rcvdid) {
+  const buf = Buffer.alloc(CONTROL_SIZE, 0);
+  buf.writeUInt32LE(CONTROL_SIZE, 0);
+  buf.writeUInt16LE(type, 4);
+  buf.writeUInt16LE(seq, 6);
+  buf.writeUInt32LE(sentid >>> 0, 8);
+  buf.writeUInt32LE(rcvdid >>> 0, 12);
+  return buf;
+}
+
+function buildPing(seq, sentid, rcvdid, time, reply) {
+  const buf = Buffer.alloc(PING_SIZE, 0);
+  buf.writeUInt32LE(PING_SIZE, 0);
+  buf.writeUInt16LE(TYPE_PING, 4);
+  buf.writeUInt16LE(seq, 6);
+  buf.writeUInt32LE(sentid >>> 0, 8);
+  buf.writeUInt32LE(rcvdid >>> 0, 12);
+  buf.writeUInt8(reply ? 1 : 0, 0x10);
+  buf.writeUInt32LE(time >>> 0, 0x11);
+  return buf;
+}
+
+function buildLoginResponse(tokRequest, token, rejected = false) {
+  const buf = Buffer.alloc(LOGIN_RESPONSE_SIZE, 0);
+  buf.writeUInt32LE(LOGIN_RESPONSE_SIZE, 0);
+  buf.writeUInt16LE(0, 4);
+  buf.writeUInt16LE(tokRequest, 0x1a);
+  buf.writeUInt32LE(token >>> 0, 0x1c);
+  if (rejected) buf.writeUInt32LE(0xfeffffff, 0x30);
+  return buf;
+}
+
+function buildTokenResponse(requestType) {
+  const buf = Buffer.alloc(TOKEN_SIZE, 0);
+  buf.writeUInt32LE(TOKEN_SIZE, 0);
+  buf.writeUInt16LE(0, 4);
+  buf.writeUInt8(0x02, 0x14); // response
+  buf.writeUInt8(requestType, 0x15);
+  buf.writeUInt32LE(0, 0x30); // accepted
+  return buf;
+}
+
+function buildStatus(civPort, audioPort) {
+  const buf = Buffer.alloc(STATUS_SIZE, 0);
+  buf.writeUInt32LE(STATUS_SIZE, 0);
+  buf.writeUInt16LE(0, 4);
+  buf.writeUInt32LE(0, 0x30); // accepted
+  buf.writeUInt16BE(civPort, 0x42);
+  buf.writeUInt16BE(audioPort || 0, 0x46);
+  return buf;
+}
+
+function writeAscii(buf, offset, len, value) {
+  Buffer.from(String(value || '').slice(0, len), 'ascii').copy(buf, offset);
+}
+
+function buildCapabilities(seq, sentid, rcvdid, tokRequest, token, radio = {}) {
+  const buf = Buffer.alloc(CAPABILITIES_SIZE + RADIO_CAP_SIZE, 0);
+  buf.writeUInt32LE(buf.length, 0);
+  buf.writeUInt16LE(0, 4);
+  buf.writeUInt16LE(seq, 6);
+  buf.writeUInt32LE(sentid >>> 0, 8);
+  buf.writeUInt32LE(rcvdid >>> 0, 12);
+  buf.writeUInt32BE(buf.length - 0x10, 0x10);
+  buf.writeUInt8(0x02, 0x14);
+  buf.writeUInt8(0x02, 0x15);
+  buf.writeUInt16BE(0, 0x16);
+  buf.writeUInt16LE(tokRequest, 0x1a);
+  buf.writeUInt32LE(token >>> 0, 0x1c);
+  buf.writeUInt16LE(1, 0x40);
+
+  const base = CAPABILITIES_SIZE;
+  const commoncap = radio.commoncap == null ? 0x8010 : radio.commoncap;
+  const mac = radio.macAddress || Buffer.from([0x00, 0x90, 0xc7, 0x12, 0x34, 0x56]);
+  buf.writeUInt16LE(commoncap, base + 0x07);
+  Buffer.from(mac).copy(buf, base + 0x0a, 0, 6);
+  writeAscii(buf, base + 0x10, 32, radio.name || 'IC-7610');
+  writeAscii(buf, base + 0x30, 32, radio.audio || 'ICOM_VAUDIO');
+  buf.writeUInt16LE(radio.conntype || 0, base + 0x50);
+  buf.writeUInt8(radio.civAddress == null ? 0x98 : radio.civAddress, base + 0x52);
+  buf.writeUInt16LE(radio.rxSampleMask == null ? 0x0004 : radio.rxSampleMask, base + 0x53);
+  buf.writeUInt16LE(radio.txSampleMask == null ? 0x0004 : radio.txSampleMask, base + 0x55);
+  buf.writeUInt32BE(radio.baudrate || 115200, base + 0x5a);
+  buf.writeUInt16LE(radio.capf || 0x5001, base + 0x5e);
+  return buf;
+}
+
+function encodeFreqBCD(hz) {
+  const digits = String(hz).padStart(10, '0');
+  const bcd = [];
+  for (let i = 8; i >= 0; i -= 2) {
+    const hi = parseInt(digits[i], 10);
+    const lo = parseInt(digits[i + 1], 10);
+    bcd.push((hi << 4) | lo);
+  }
+  return bcd;
+}
+
+function buildCivData(seq, sentid, rcvdid, sendSeqB, civPayload) {
+  const total = CIV_HEADER_SIZE + civPayload.length;
+  const buf = Buffer.alloc(total, 0);
+  buf.writeUInt32LE(total, 0);
+  buf.writeUInt16LE(0, 4);
+  buf.writeUInt16LE(seq, 6);
+  buf.writeUInt32LE(sentid >>> 0, 8);
+  buf.writeUInt32LE(rcvdid >>> 0, 12);
+  buf.writeUInt8(0xc1, 0x10);
+  buf.writeUInt16LE(civPayload.length, 0x11);
+  buf.writeUInt16BE(sendSeqB, 0x13);
+  civPayload.copy(buf, CIV_HEADER_SIZE);
+  return buf;
+}
+
+function buildAudioData(seq, sentid, rcvdid, sendSeqB, samples) {
+  const payload = Buffer.alloc(samples.length * 2);
+  for (let i = 0; i < samples.length; i++) {
+    payload.writeInt16LE(samples[i], i * 2);
+  }
+  const total = AUDIO_HEADER_SIZE + payload.length;
+  const buf = Buffer.alloc(total, 0);
+  buf.writeUInt32LE(total, 0);
+  buf.writeUInt16LE(0, 4);
+  buf.writeUInt16LE(seq, 6);
+  buf.writeUInt32LE(sentid >>> 0, 8);
+  buf.writeUInt32LE(rcvdid >>> 0, 12);
+  buf.writeUInt16BE(0x0244, 0x10);
+  buf.writeUInt16BE(sendSeqB, 0x12);
+  buf.writeUInt16BE(payload.length, 0x16);
+  payload.copy(buf, AUDIO_HEADER_SIZE);
+  return buf;
+}
+
+function waitFor(emitter, event, timeoutMs = 1500) {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timed out waiting for ${event}`));
+    }, timeoutMs);
+    const onEvent = (...args) => {
+      cleanup();
+      resolve(args);
+    };
+    const cleanup = () => {
+      clearTimeout(timeout);
+      emitter.removeListener(event, onEvent);
+    };
+    emitter.once(event, onEvent);
+  });
+}
+
+function waitUntil(predicate, timeoutMs = 1500, label = 'condition') {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const tick = () => {
+      if (predicate()) return resolve();
+      if (Date.now() - start >= timeoutMs) return reject(new Error(`Timed out waiting for ${label}`));
+      setTimeout(tick, 10);
+    };
+    tick();
+  });
+}
+
+function decodeLpcm16Payload(payload) {
+  const out = [];
+  for (let i = 0; i + 1 < payload.length; i += 2) {
+    out.push(payload.readInt16LE(i));
+  }
+  return out;
+}
+
+async function reserveUdpPortPair() {
+  for (let i = 0; i < 50; i++) {
+    const first = await new Promise((resolve, reject) => {
+      const sock = dgram.createSocket('udp4');
+      sock.once('error', reject);
+      sock.bind(0, '127.0.0.1', () => {
+        const port = sock.address().port;
+        sock.close(() => resolve(port));
+      });
+    });
+    const second = first + 1;
+    const sockets = [];
+    try {
+      for (const port of [first, second]) {
+        sockets.push(await new Promise((resolve, reject) => {
+          const sock = dgram.createSocket('udp4');
+          sock.once('error', reject);
+          sock.bind(port, '127.0.0.1', () => resolve(sock));
+        }));
+      }
+      await Promise.all(sockets.map((sock) => new Promise((resolve) => sock.close(resolve))));
+      return { controlPort: first, civPort: second };
+    } catch {
+      await Promise.all(sockets.map((sock) => new Promise((resolve) => {
+        try { sock.close(resolve); } catch { resolve(); }
+      })));
+    }
+  }
+  throw new Error('Could not find a free consecutive UDP port pair');
+}
+
+class MockRsBa1Server {
+  constructor({ username = 'user', password = 'pass', radioAddr = 0x94, frequencyHz = 14074000, controlPort = 0, civPort = 0, audioPort = 0, advertisedCivPort = null, advertisedAudioPort = null, requiredCivOpenCount = 1, tokenFlow = 'capabilities', dropLoginPackets = 0, txSampleMask = 0x0004 } = {}) {
+    this.username = username;
+    this.password = password;
+    this.radioAddr = radioAddr;
+    this.frequencyHz = frequencyHz;
+    this.bindControlPort = controlPort;
+    this.bindCivPort = civPort;
+    this.bindAudioPort = audioPort;
+    this.advertisedCivPort = advertisedCivPort;
+    this.advertisedAudioPort = advertisedAudioPort;
+    this.requiredCivOpenCount = Math.max(1, Number(requiredCivOpenCount) || 1);
+    this.tokenFlow = tokenFlow;
+    this.dropLoginPackets = Math.max(0, Number(dropLoginPackets) || 0);
+    this.txSampleMask = txSampleMask;
+    this.loginPacketCount = 0;
+    this.radioMacAddress = Buffer.from([0x00, 0x90, 0xc7, 0x12, 0x34, 0x56]);
+    this.controlId = 0x12345678;
+    this.civId = 0x23456789;
+    this.audioId = 0x3456789a;
+    this.token = 0x0badcafe;
+    this.controlSeq = 0;
+    this.civSeq = 0;
+    this.civSendSeq = 0;
+    this.audioSeq = 0;
+    this.audioSendSeq = 0;
+    this.audioPingReplies = 0;
+    this.controlClientId = 0;
+    this.civClientId = 0;
+    this.audioClientId = 0;
+    this.controlClient = null;
+    this.civClient = null;
+    this.audioClient = null;
+    this.lastConnInfo = null;
+    this.lastToken = null;
+    this.tokenRemovalCount = 0;
+    this.requestedCivLocalPort = 0;
+    this.requestedAudioLocalPort = 0;
+    this.civOpened = false;
+    this.civOpenCount = 0;
+    this.audioOpened = false;
+    this.txAudioPackets = [];
+    this.control = null;
+    this.civ = null;
+    this.audio = null;
+  }
+
+  async start() {
+    this.control = await this._bind((msg, rinfo) => this._onControl(msg, rinfo), this.bindControlPort);
+    this.civ = await this._bind((msg, rinfo) => this._onCiv(msg, rinfo), this.bindCivPort);
+    this.audio = await this._bind((msg, rinfo) => this._onAudio(msg, rinfo), this.bindAudioPort);
+    this.controlPort = this.control.address().port;
+    this.civPort = this.civ.address().port;
+    this.audioPort = this.audio.address().port;
+  }
+
+  async stop() {
+    await Promise.all([this._close(this.control), this._close(this.civ), this._close(this.audio)]);
+  }
+
+  _bind(onMessage, port = 0) {
+    return new Promise((resolve, reject) => {
+      const sock = dgram.createSocket('udp4');
+      sock.on('message', onMessage);
+      sock.once('error', reject);
+      sock.bind(port, '127.0.0.1', () => resolve(sock));
+    });
+  }
+
+  _close(sock) {
+    return new Promise((resolve) => {
+      if (!sock) return resolve();
+      try { sock.close(resolve); } catch { resolve(); }
+    });
+  }
+
+  _send(sock, buf, rinfo) {
+    sock.send(buf, rinfo.port, rinfo.address);
+  }
+
+  _replyControl(type, rinfo) {
+    this._send(this.control, buildControl(type, this.controlSeq++, this.controlId, this.controlClientId), rinfo);
+  }
+
+  _replyCivControl(type, rinfo) {
+    this._send(this.civ, buildControl(type, this.civSeq++, this.civId, this.civClientId), rinfo);
+  }
+
+  _replyAudioControl(type, rinfo) {
+    this._send(this.audio, buildControl(type, this.audioSeq++, this.audioId, this.audioClientId), rinfo);
+  }
+
+  sendAudioFrame(samples = [0, 16384, -16384, 32767]) {
+    if (!this.audioClient) return;
+    this._send(this.audio, buildAudioData(this.audioSeq++, this.audioId, this.audioClientId, this.audioSendSeq++, samples), this.audioClient);
+  }
+
+  sendUnsolicitedAudioPing() {
+    if (!this.requestedAudioLocalPort) return;
+    this._send(this.audio, buildPing(this.audioSeq++, this.audioId, this.audioClientId, Date.now() >>> 0, false), {
+      address: (this.controlClient && this.controlClient.address) || '127.0.0.1',
+      port: this.requestedAudioLocalPort,
+    });
+  }
+
+  _onControl(msg, rinfo) {
+    if (msg.length < 4) return;
+    const len = msg.readUInt32LE(0);
+    if (len === CONTROL_SIZE) {
+      const type = msg.readUInt16LE(4);
+      this.controlClientId = msg.readUInt32LE(8);
+      this.controlClient = rinfo;
+      if (type === TYPE_AYT) this._replyControl(TYPE_IAMHERE, rinfo);
+      else if (type === TYPE_AYR_IAR) this._replyControl(TYPE_AYR_IAR, rinfo);
+      else if (type === TYPE_DISCONNECT) return;
+      else if (type === TYPE_RETRANSMIT) return;
+      return;
+    }
+
+    if (len === PING_SIZE) {
+      if (msg.readUInt8(0x10) === 0) {
+        const seq = msg.readUInt16LE(6);
+        const time = msg.readUInt32LE(0x11);
+        this._send(this.control, buildPing(seq, this.controlId, this.controlClientId, time, true), rinfo);
+      }
+      return;
+    }
+
+    if (len === LOGIN_SIZE) {
+      this.loginPacketCount++;
+      if (this.loginPacketCount <= this.dropLoginPackets) return;
+      const tokRequest = msg.readUInt16LE(0x1a);
+      const userOk = msg.slice(0x40, 0x50).equals(passcodeBytes(this.username, 16));
+      const passOk = msg.slice(0x50, 0x60).equals(passcodeBytes(this.password, 16));
+      this._send(this.control, buildLoginResponse(tokRequest, this.token, !(userOk && passOk)), rinfo);
+      return;
+    }
+
+    if (len === TOKEN_SIZE) {
+      const requestType = msg.readUInt8(0x15);
+      this.lastToken = msg;
+      if (requestType === 0x01) this.tokenRemovalCount++;
+      if (requestType === 0x02 && this.tokenFlow === 'capabilities') {
+        const tokRequest = msg.readUInt16LE(0x1a);
+        const token = msg.readUInt32LE(0x1c);
+        this._send(this.control, buildCapabilities(this.controlSeq++, this.controlId, this.controlClientId, tokRequest, token, {
+          name: 'IC-7610',
+          civAddress: this.radioAddr,
+          macAddress: this.radioMacAddress,
+          txSampleMask: this.txSampleMask,
+        }), rinfo);
+      } else {
+        this._send(this.control, buildTokenResponse(requestType), rinfo);
+      }
+      return;
+    }
+
+    if (len === CONNINFO_SIZE) {
+      this.lastConnInfo = msg;
+      this.requestedCivLocalPort = msg.readUInt32BE(0x7c);
+      this.requestedAudioLocalPort = msg.readUInt32BE(0x80);
+      const advertisedAudio = this.advertisedAudioPort == null ? this.audioPort : this.advertisedAudioPort;
+      this._send(this.control, buildStatus(this.advertisedCivPort || this.civPort, advertisedAudio), rinfo);
+    }
+  }
+
+  _onCiv(msg, rinfo) {
+    if (msg.length < 4) return;
+    if (this.requestedCivLocalPort && rinfo.port !== this.requestedCivLocalPort) return;
+    const len = msg.readUInt32LE(0);
+    if (len === CONTROL_SIZE) {
+      const type = msg.readUInt16LE(4);
+      this.civClientId = msg.readUInt32LE(8);
+      this.civClient = rinfo;
+      if (type === TYPE_AYT) {
+        this._replyCivControl(TYPE_IAMHERE, rinfo);
+      } else if (type === TYPE_AYR_IAR) {
+        this._replyCivControl(TYPE_AYR_IAR, rinfo);
+      }
+      return;
+    }
+
+    if (len === PING_SIZE) {
+      if (msg.readUInt8(0x10) === 0) {
+        const seq = msg.readUInt16LE(6);
+        const time = msg.readUInt32LE(0x11);
+        this._send(this.civ, buildPing(seq, this.civId, this.civClientId, time, true), rinfo);
+      }
+      return;
+    }
+
+    if (len === OPENCLOSE_SIZE) {
+      const openData = msg.readUInt16LE(0x10);
+      const magic = msg.readUInt8(0x15);
+      const sendSeq = msg.readUInt16BE(0x13);
+      if (openData === 0x01c0 && magic === 0x04) {
+        assert.strictEqual(sendSeq, this.civOpenCount);
+        this.civOpenCount++;
+        if (this.civOpenCount >= this.requiredCivOpenCount) this.civOpened = true;
+      }
+      return;
+    }
+
+    if (len > CIV_HEADER_SIZE && msg.readUInt8(0x10) === 0xc1) {
+      if (!this.civOpened) return;
+      const datalen = msg.readUInt16LE(0x11);
+      const payload = msg.slice(CIV_HEADER_SIZE, CIV_HEADER_SIZE + datalen);
+      const cmd = payload[4];
+      if (cmd === 0x03) {
+        const response = Buffer.from([
+          0xfe, 0xfe, 0xe0, this.radioAddr, 0x03,
+          ...encodeFreqBCD(this.frequencyHz),
+          0xfd,
+        ]);
+        this._send(this.civ, buildCivData(this.civSeq++, this.civId, this.civClientId, this.civSendSeq++, response), rinfo);
+      }
+    }
+  }
+
+  _onAudio(msg, rinfo) {
+    if (msg.length < 4) return;
+    if (this.requestedAudioLocalPort && rinfo.port !== this.requestedAudioLocalPort) return;
+    const len = msg.readUInt32LE(0);
+    if (len === CONTROL_SIZE) {
+      const type = msg.readUInt16LE(4);
+      this.audioClientId = msg.readUInt32LE(8);
+      this.audioClient = rinfo;
+      if (type === TYPE_AYT) {
+        this._replyAudioControl(TYPE_IAMHERE, rinfo);
+      } else if (type === TYPE_AYR_IAR) {
+        this._replyAudioControl(TYPE_AYR_IAR, rinfo);
+      }
+      return;
+    }
+
+    if (len === PING_SIZE) {
+      if (msg.readUInt8(0x10) === 1) {
+        this.audioPingReplies++;
+      } else if (msg.readUInt8(0x10) === 0) {
+        const seq = msg.readUInt16LE(6);
+        const time = msg.readUInt32LE(0x11);
+        this._send(this.audio, buildPing(seq, this.audioId, this.audioClientId, time, true), rinfo);
+      }
+      return;
+    }
+
+    if (len === OPENCLOSE_SIZE) {
+      const openData = msg.readUInt16LE(0x10);
+      const magic = msg.readUInt8(0x15);
+      if (openData === 0x01c0 && magic === 0x04) {
+        this.audioOpened = true;
+      }
+      if (!this.audioOpened) return;
+      this.sendAudioFrame();
+      return;
+    }
+
+    if (len > AUDIO_HEADER_SIZE) {
+      if (!this.audioOpened) return;
+      const datalen = msg.readUInt16BE(0x16);
+      this.txAudioPackets.push({
+        msg,
+        ident: msg.readUInt16LE(0x10),
+        sendSeq: msg.readUInt16BE(0x12),
+        datalen,
+        payload: msg.slice(AUDIO_HEADER_SIZE, AUDIO_HEADER_SIZE + datalen),
+      });
+    }
+  }
+}
+
+async function withServer(opts, fn) {
+  const server = new MockRsBa1Server(opts);
+  await server.start();
+  try {
+    return await fn(server);
+  } finally {
+    await server.stop();
+  }
+}
+
+async function main() {
+  console.log('\n=== RS-BA1 Transport ===');
+
+  await test('prefers same-subnet LAN address over tunnel route for stream IDs', async () => {
+    const fakeInterfaces = {
+      en0: [{
+        family: 'IPv4',
+        address: '10.0.1.7',
+        netmask: '255.255.254.0',
+        internal: false,
+      }],
+      utun9: [{
+        family: 'IPv4',
+        address: '100.92.40.38',
+        netmask: '255.255.255.255',
+        internal: false,
+      }],
+    };
+    const selected = selectLocalAddressForTarget('10.0.0.75', '100.92.40.38', fakeInterfaces);
+    assert.strictEqual(selected.address, '10.0.1.7');
+    assert.strictEqual(selected.source, 'same-subnet');
+    assert.strictEqual(selected.interfaceName, 'en0');
+  });
+
+  await test('connects, uses assigned CIV port, and carries CI-V frequency frames', async () => {
+    await withServer({ username: 'alice', password: 'secret', frequencyHz: 7074000 }, async (server) => {
+      const transport = new RsBa1Transport();
+      const errors = [];
+      transport.on('error', (err) => errors.push(err));
+      transport.connect({
+        host: '127.0.0.1',
+        controlPort: server.controlPort,
+        username: 'alice',
+        password: 'secret',
+      });
+
+      await waitFor(transport, 'connect');
+      assert.strictEqual(transport.connected, true);
+
+      const dataPromise = waitFor(transport, 'data');
+      transport.write(Buffer.from([0xfe, 0xfe, 0x94, 0xe0, 0x03, 0xfd]));
+      const [frame] = await dataPromise;
+      assert.deepStrictEqual([...frame], [0xfe, 0xfe, 0xe0, 0x94, 0x03, 0x00, 0x40, 0x07, 0x07, 0x00, 0xfd]);
+      assert.strictEqual(server.civClient.port > 0, true);
+      assert.strictEqual(server.requestedCivLocalPort, server.civClient.port);
+      assert.ok(server.controlClientId > 0);
+      assert.strictEqual(server.civClientId, streamIdFromLocalAddress('127.0.0.1', server.civClient.port));
+      assert.strictEqual(server.lastToken.readUInt16BE(0x24), 0x0798);
+      assert.deepStrictEqual([...server.lastConnInfo.slice(0x2a, 0x30)], [...server.radioMacAddress]);
+      assert.strictEqual(server.lastConnInfo.toString('ascii', 0x40, 0x47).replace(/\0/g, ''), 'IC-7610');
+      assert.strictEqual(server.lastConnInfo.readUInt8(0x70), 0);
+      assert.deepStrictEqual(errors, []);
+
+      transport.disconnect();
+    });
+  });
+
+  await test('sends RS-BA1 token removal when disconnecting an authenticated session', async () => {
+    await withServer({ username: 'alice', password: 'secret' }, async (server) => {
+      const transport = new RsBa1Transport();
+      transport.connect({
+        host: '127.0.0.1',
+        controlPort: server.controlPort,
+        username: 'alice',
+        password: 'secret',
+      });
+
+      await waitFor(transport, 'connect');
+      transport.disconnect();
+      await waitUntil(() => server.tokenRemovalCount >= 2, 500, 'token removal packets');
+    });
+  });
+
+  await test('rejects invalid username/password', async () => {
+    await withServer({ username: 'alice', password: 'secret' }, async (server) => {
+      const transport = new RsBa1Transport();
+      const errorPromise = waitFor(transport, 'error');
+      transport.connect({
+        host: '127.0.0.1',
+        controlPort: server.controlPort,
+        username: 'alice',
+        password: 'wrong',
+      });
+
+      const [err] = await errorPromise;
+      assert.match(err.message, /authentication failed: invalid-credentials/);
+      assert.strictEqual(transport.connected, false);
+      transport.disconnect();
+    });
+  });
+
+  await test('retries the exact Login packet when the first copy is lost', async () => {
+    await withServer({ username: 'alice', password: 'secret', dropLoginPackets: 1 }, async (server) => {
+      const transport = new RsBa1Transport();
+      const logs = [];
+      transport.on('log', (line) => logs.push(String(line)));
+      transport.connect({
+        host: '127.0.0.1',
+        controlPort: server.controlPort,
+        username: 'alice',
+        password: 'secret',
+      });
+
+      await waitFor(transport, 'connect', 4000);
+      assert.strictEqual(server.loginPacketCount >= 2, true);
+      assert.ok(logs.some((line) => line.includes('retry Login')));
+      transport.disconnect();
+    });
+  });
+
+  await test('falls back to control+1 when advertised CIV port does not answer', async () => {
+    const ports = await reserveUdpPortPair();
+    const advertisedCivPort = ports.civPort > 64535 ? ports.civPort - 1000 : ports.civPort + 1000;
+    await withServer({
+      username: 'alice',
+      password: 'secret',
+      controlPort: ports.controlPort,
+      civPort: ports.civPort,
+      advertisedCivPort,
+      frequencyHz: 14230000,
+    }, async (server) => {
+      const transport = new RsBa1Transport();
+      const logs = [];
+      transport.on('log', (line) => logs.push(line));
+      transport.connect({
+        host: '127.0.0.1',
+        controlPort: server.controlPort,
+        username: 'alice',
+        password: 'secret',
+      });
+
+      await waitFor(transport, 'connect', 7000);
+      assert.strictEqual(transport.connected, true);
+      assert.strictEqual(server.requestedCivLocalPort, server.civClient.port);
+      assert.ok(logs.some((line) => line.includes(`retrying fallback port ${ports.civPort}`)));
+
+      const dataPromise = waitFor(transport, 'data');
+      transport.write(Buffer.from([0xfe, 0xfe, 0x94, 0xe0, 0x03, 0xfd]));
+      const [frame] = await dataPromise;
+      assert.deepStrictEqual([...frame], [0xfe, 0xfe, 0xe0, 0x94, 0x03, 0x00, 0x00, 0x23, 0x14, 0x00, 0xfd]);
+
+      transport.disconnect();
+    });
+  });
+
+  await test('opens RS-BA1 audio stream and decodes LPCM16 mono RX frames', async () => {
+    await withServer({ username: 'alice', password: 'secret' }, async (server) => {
+      const transport = new RsBa1Transport();
+      const connectPromise = waitFor(transport, 'connect');
+      const audioReadyPromise = waitFor(transport, 'audio-ready');
+      const audioPromise = waitFor(transport, 'audio-frame');
+      transport.connect({
+        host: '127.0.0.1',
+        controlPort: server.controlPort,
+        username: 'alice',
+        password: 'secret',
+        enableRxAudio: true,
+        rxAudioSampleRate: 48000,
+      });
+
+      await connectPromise;
+      await audioReadyPromise;
+      const [frame] = await audioPromise;
+      assert.strictEqual(frame.sampleRate, 48000);
+      assert.strictEqual(frame.pcm.length, 4);
+      assert.strictEqual(frame.pcm[0], 0);
+      assert.strictEqual(frame.pcm[1], 0.5);
+      assert.strictEqual(frame.pcm[2], -0.5);
+      assert.ok(Math.abs(frame.pcm[3] - (32767 / 32768)) < 1e-7);
+      assert.strictEqual(server.requestedCivLocalPort, server.civClient.port);
+      assert.strictEqual(server.requestedAudioLocalPort, server.audioClient.port);
+      assert.strictEqual(server.lastConnInfo.readUInt8(0x70), 1);
+      assert.strictEqual(server.lastConnInfo.readUInt8(0x72), AUDIO_CODEC_LPCM16_MONO);
+      assert.strictEqual(server.lastConnInfo.readUInt32BE(0x74), 48000);
+
+      transport.disconnect();
+    });
+  });
+
+  await test('negotiates and sends RS-BA1 LPCM16 mono TX audio packets', async () => {
+    await withServer({ username: 'alice', password: 'secret' }, async (server) => {
+      const transport = new RsBa1Transport();
+      const connectPromise = waitFor(transport, 'connect');
+      const audioReadyPromise = waitFor(transport, 'audio-ready');
+      transport.connect({
+        host: '127.0.0.1',
+        controlPort: server.controlPort,
+        username: 'alice',
+        password: 'secret',
+        enableRxAudio: true,
+        enableTxAudio: true,
+        rxAudioSampleRate: 48000,
+        txAudioSampleRate: 48000,
+      });
+
+      await connectPromise;
+      await audioReadyPromise;
+      assert.strictEqual(transport.txReady, true);
+      assert.strictEqual(server.lastConnInfo.readUInt8(0x70), 1);
+      assert.strictEqual(server.lastConnInfo.readUInt8(0x71), 1);
+      assert.strictEqual(server.lastConnInfo.readUInt8(0x72), AUDIO_CODEC_LPCM16_MONO);
+      assert.strictEqual(server.lastConnInfo.readUInt8(0x73), AUDIO_CODEC_LPCM16_MONO);
+      assert.strictEqual(server.lastConnInfo.readUInt32BE(0x78), 48000);
+      assert.strictEqual(server.lastConnInfo.readUInt32BE(0x84), 250);
+
+      const samples = new Float32Array(700);
+      samples[0] = 0;
+      samples[1] = 0.5;
+      samples[2] = -0.5;
+      samples[3] = 1;
+      for (let i = 4; i < samples.length; i++) samples[i] = (i % 10) / 20;
+      await transport.sendTxAudio(samples, { offsetMs: 500, inputSampleRate: 48000, tailSilenceMs: 0 });
+      await waitUntil(() => server.txAudioPackets.length >= 2, 1000, 'TX audio packets');
+
+      assert.strictEqual(server.txAudioPackets.length, 2);
+      assert.strictEqual(server.txAudioPackets[0].datalen, 1364);
+      assert.strictEqual(server.txAudioPackets[1].datalen, 36);
+      assert.strictEqual(server.txAudioPackets[0].ident, 0x0080);
+      assert.strictEqual(server.txAudioPackets[0].sendSeq, 0);
+      assert.strictEqual(server.txAudioPackets[1].sendSeq, 1);
+      const payload = Buffer.concat(server.txAudioPackets.map((p) => p.payload));
+      assert.strictEqual(payload.length, 1400);
+      assert.deepStrictEqual(decodeLpcm16Payload(payload.slice(0, 8)), [0, 16384, -16384, 32767]);
+
+      transport.disconnect();
+    });
+  });
+
+  await test('groups TX audio into wfview-style 20ms frames before splitting UDP chunks', async () => {
+    await withServer({ includeAudio: true, enableTxAudio: true }, async (server) => {
+      const transport = new RsBa1Transport({ log: () => {} });
+      const audioReadyPromise = waitFor(transport, 'audio-ready', 1500);
+      const connectPromise = waitFor(transport, 'connect', 1500);
+      transport.connect({
+        host: '127.0.0.1',
+        controlPort: server.controlPort,
+        username: 'user',
+        password: 'pass',
+        enableRxAudio: true,
+        enableTxAudio: true,
+        timeoutMs: 1500,
+      });
+
+      await connectPromise;
+      await audioReadyPromise;
+
+      const samples = new Float32Array(1920); // 40ms at 48kHz = two 20ms frames
+      for (let i = 0; i < samples.length; i++) samples[i] = i % 2 ? 0.25 : -0.25;
+      await transport.sendTxAudio(samples, { offsetMs: 500, inputSampleRate: 48000, tailSilenceMs: 0 });
+      await waitUntil(() => server.txAudioPackets.length >= 4, 1000, '20ms TX audio frame packets');
+
+      assert.deepStrictEqual(server.txAudioPackets.map((p) => p.datalen), [1364, 556, 1364, 556]);
+      assert.deepStrictEqual(server.txAudioPackets.map((p) => p.sendSeq), [0, 1, 2, 3]);
+
+      transport.disconnect();
+    });
+  });
+
+  await test('sends 16kHz RS-BA1 TX audio as unsplit 20ms mono frames', async () => {
+    await withServer({ includeAudio: true, enableTxAudio: true }, async (server) => {
+      const transport = new RsBa1Transport({ log: () => {} });
+      const audioReadyPromise = waitFor(transport, 'audio-ready', 1500);
+      const connectPromise = waitFor(transport, 'connect', 1500);
+      transport.connect({
+        host: '127.0.0.1',
+        controlPort: server.controlPort,
+        username: 'user',
+        password: 'pass',
+        enableRxAudio: true,
+        enableTxAudio: true,
+        txAudioSampleRate: 16000,
+        txAudioBufferMs: 750,
+        timeoutMs: 1500,
+      });
+
+      await connectPromise;
+      await audioReadyPromise;
+      assert.strictEqual(server.lastConnInfo.readUInt32BE(0x78), 16000);
+      assert.strictEqual(server.lastConnInfo.readUInt32BE(0x84), 750);
+
+      const samples = new Float32Array(640); // 40ms at 16kHz = two 20ms frames
+      for (let i = 0; i < samples.length; i++) samples[i] = i % 2 ? 0.2 : -0.2;
+      await transport.sendTxAudio(samples, {
+        offsetMs: 0,
+        inputSampleRate: 16000,
+        startDelayMs: 0,
+        tailSilenceMs: 0,
+      });
+      await waitUntil(() => server.txAudioPackets.length >= 2, 1000, '16kHz TX audio packets');
+
+      assert.deepStrictEqual(server.txAudioPackets.map((p) => p.datalen), [640, 640]);
+      assert.deepStrictEqual(server.txAudioPackets.map((p) => p.sendSeq), [0, 1]);
+
+      transport.disconnect();
+    });
+  });
+
+  await test('duplicates mono TX audio into RS-BA1 PCM16 stereo packets when negotiated', async () => {
+    await withServer({ includeAudio: true, enableTxAudio: true }, async (server) => {
+      const transport = new RsBa1Transport({ log: () => {} });
+      const audioReadyPromise = waitFor(transport, 'audio-ready', 1500);
+      const connectPromise = waitFor(transport, 'connect', 1500);
+      transport.connect({
+        host: '127.0.0.1',
+        controlPort: server.controlPort,
+        username: 'user',
+        password: 'pass',
+        enableRxAudio: true,
+        enableTxAudio: true,
+        txAudioCodec: AUDIO_CODEC_LPCM16_STEREO,
+        timeoutMs: 1500,
+      });
+
+      await connectPromise;
+      await audioReadyPromise;
+      assert.strictEqual(server.lastConnInfo.readUInt8(0x73), AUDIO_CODEC_LPCM16_STEREO);
+
+      const samples = new Float32Array(960); // 20ms at 48kHz, one stereo frame after duplication
+      samples[0] = 0.5;
+      samples[1] = -0.5;
+      for (let i = 2; i < samples.length; i++) samples[i] = i % 2 ? 0.25 : -0.25;
+      await transport.sendTxAudio(samples, { offsetMs: 500, inputSampleRate: 48000, tailSilenceMs: 0 });
+      await waitUntil(() => server.txAudioPackets.length >= 3, 1000, 'stereo TX audio packets');
+
+      assert.deepStrictEqual(server.txAudioPackets.map((p) => p.datalen), [1364, 1364, 1112]);
+      const payload = Buffer.concat(server.txAudioPackets.map((p) => p.payload));
+      assert.strictEqual(payload.length, 3840);
+      assert.deepStrictEqual(decodeLpcm16Payload(payload.slice(0, 8)), [16384, 16384, -16384, -16384]);
+
+      transport.disconnect();
+    });
+  });
+
+  await test('uses band-limited upsampling for 12kHz JTCAT TX audio', async () => {
+    const inputRate = 12000;
+    const outputRate = 48000;
+    const toneHz = 1500;
+    const src = new Float32Array(inputRate / 10);
+    for (let i = 0; i < src.length; i++) {
+      src[i] = Math.sin(2 * Math.PI * toneHz * i / inputRate) * 0.25;
+    }
+
+    const out = resampleMonoFloat32(src, inputRate, outputRate);
+    assert.strictEqual(out.length, src.length * 4);
+
+    let peak = 0;
+    let rms = 0;
+    for (let i = outputRate / 100; i < out.length - outputRate / 100; i++) {
+      const v = out[i];
+      peak = Math.max(peak, Math.abs(v));
+      rms += v * v;
+    }
+    rms = Math.sqrt(rms / (out.length - outputRate / 50));
+
+    assert.ok(peak > 0.23 && peak < 0.27, `unexpected resampled peak ${peak}`);
+    assert.ok(rms > 0.16 && rms < 0.19, `unexpected resampled rms ${rms}`);
+  });
+
+  await test('learns audio remote port from inbound packets before replying', async () => {
+    await withServer({ includeAudio: true, enableTxAudio: true, advertisedAudioPort: 0 }, async (server) => {
+      const transport = new RsBa1Transport();
+      const connectPromise = waitFor(transport, 'connect', 1500);
+      transport.connect({
+        host: '127.0.0.1',
+        controlPort: server.controlPort,
+        username: 'user',
+        password: 'pass',
+        enableRxAudio: true,
+        enableTxAudio: true,
+        timeoutMs: 1500,
+      });
+
+      await connectPromise;
+      await waitUntil(() => server.requestedAudioLocalPort > 0, 1000, 'audio local port request');
+      server.sendUnsolicitedAudioPing();
+      await waitUntil(() => server.audioPingReplies >= 1, 1000, 'audio ping reply after learned port');
+
+      assert.strictEqual(transport.audio.port, server.audioPort);
+
+      transport.disconnect();
+    });
+  });
+
+  await test('does not enable RS-BA1 TX audio when radio capabilities reject it', async () => {
+    await withServer({ username: 'alice', password: 'secret', txSampleMask: 0x0001 }, async (server) => {
+      const transport = new RsBa1Transport();
+      const connectPromise = waitFor(transport, 'connect');
+      const audioReadyPromise = waitFor(transport, 'audio-ready');
+      transport.connect({
+        host: '127.0.0.1',
+        controlPort: server.controlPort,
+        username: 'alice',
+        password: 'secret',
+        enableRxAudio: true,
+        enableTxAudio: true,
+      });
+
+      await connectPromise;
+      await audioReadyPromise;
+      assert.strictEqual(server.lastConnInfo.readUInt8(0x71), 0);
+      assert.strictEqual(transport.txReady, false);
+      await assert.rejects(
+        () => transport.sendTxAudio(new Float32Array([0.1]), 500, 48000),
+        /not negotiated/
+      );
+      transport.disconnect();
+    });
+  });
+
+  await test('retries CI-V OpenClose until the stream accepts data', async () => {
+    await withServer({ username: 'alice', password: 'secret', requiredCivOpenCount: 3, frequencyHz: 18100000 }, async (server) => {
+      const transport = new RsBa1Transport();
+      transport.connect({
+        host: '127.0.0.1',
+        controlPort: server.controlPort,
+        username: 'alice',
+        password: 'secret',
+      });
+
+      await waitFor(transport, 'connect');
+      await new Promise((resolve) => setTimeout(resolve, 350));
+      assert.ok(server.civOpenCount >= 3, `Expected repeated OpenClose packets, got ${server.civOpenCount}`);
+
+      const dataPromise = waitFor(transport, 'data');
+      transport.write(Buffer.from([0xfe, 0xfe, 0x94, 0xe0, 0x03, 0xfd]));
+      const [frame] = await dataPromise;
+      assert.deepStrictEqual([...frame], [0xfe, 0xfe, 0xe0, 0x94, 0x03, 0x00, 0x00, 0x10, 0x18, 0x00, 0xfd]);
+
+      transport.disconnect();
+    });
+  });
+
+  await test('reports no-IAmHere timeout before credential validation', async () => {
+    const blackhole = dgram.createSocket('udp4');
+    await new Promise((resolve, reject) => {
+      blackhole.once('error', reject);
+      blackhole.bind(0, '127.0.0.1', resolve);
+    });
+    try {
+      const transport = new RsBa1Transport();
+      const errorPromise = waitFor(transport, 'error', 1000);
+      transport.connect({
+        host: 'localhost',
+        controlPort: blackhole.address().port,
+        username: 'alice',
+        password: 'secret',
+        timeoutMs: 200,
+      });
+
+      const [err] = await errorPromise;
+      assert.strictEqual(err.code, 'RSBA1_NO_IAMHERE');
+      assert.match(err.message, /before IAmHere/);
+      assert.match(err.message, /before username\/password validation/);
+      assert.strictEqual(err.details.host, 'localhost');
+      assert.strictEqual(err.details.resolvedHost, '127.0.0.1');
+      assert.ok(err.details.controlAytCount >= 1);
+      assert.strictEqual(transport.connected, false);
+      transport.disconnect();
+    } finally {
+      await new Promise((resolve) => {
+        try { blackhole.close(resolve); } catch { resolve(); }
+      });
+    }
+  });
+
+  console.log('\n==================================================');
+  console.log(`Results: ${passed} passed, ${failed} failed`);
+  if (failed > 0) {
+    console.log('SOME TESTS FAILED');
+    process.exitCode = 1;
+  } else {
+    console.log('ALL TESTS PASSED');
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Context

This is PR 3 of 3 for full RS-BA1 support. It builds on [PR #47](https://github.com/Waffleslop/POTACAT/pull/47) (transport) and [PR #48](https://github.com/Waffleslop/POTACAT/pull/48) (settings UI) and wires everything into the main application loop. Together, these three PRs make Icom Network / RS-BA1 fully functional end-to-end — add the radio, hit Save, and it connects.

This is the largest of the three PRs. Happy to split it further if helpful — the ECHOCAT voice TX section and the profile-switch teardown are the most separable pieces.

## What's included

### Connection management
- `_icomNetworkTransport` + `ICOM_NETWORK_*` constants
- `connectIcomNetwork()` with exponential backoff retry (3s → 6s → 12s → 24s → 45s → 75s)
- `isRetriableIcomNetworkConnectError()` — avoids spinning on bad credentials
- 3.5s startup delay so the radio releases any previous RS-BA1 session
- Transport event routing: CI-V data → CivCodec, rx-audio → consumers, errors → UI + reconnect

### RX audio path
- `IcomNetworkRxPacer` — smooths UDP jitter into a steady 20ms frame stream; emits bounded catch-up frames when the event loop fires late
- `handleIcomNetworkAudioFrame()` — decodes RS-BA1 LPCM16 → Float32, routes to JTCAT, SSTV, and ECHOCAT bridge; PLC repeats last good frame on gap
- `startIcomNetworkRxWatchdog()` — audio-only restart after 8s stall; full reconnect after 3 failed restarts
- `rsba1-rx-diagnostics.log` — RX-GAP, RX-STALL, TX events, retransmits logged for offline analysis

### TX audio path
- `conditionDirectTxAudio()` — TX gain, peak limiting, degenerate-audio abort
- `analyzeDigitalTxEnvelope()` — FT8/FT4 slot timing
- Direct TX dispatch from JTCAT and SSTV via `sendTxAudio()`
- `restoreIcomNetworkDataMod()` — reverts DATA1 MOD source on disconnect

### Settings integration
- `test-icom-network` IPC handler for the Test Connection button
- `networkTxGain` applied to all TX audio paths
- `catTarget.type === 'icom-network'` routing in `connectCat()`

### Also bundled (separable if preferred)
- **ECHOCAT voice TX** — phone mic PTT → RS-BA1 streaming audio path (validated: SSB POTA hunt logged over IP)
- **Profile-switch RS-BA1 teardown** — graceful disconnect before profile switch / app restart

> **AI disclosure**: implementation by Codex + Claude Code, validated on IC-7610 with real FT8 contacts and an SSB POTA hunt over IP. See PR #47 for full hardware validation notes.