### PR TITLE
fix native ft8 build on macOS 26.5.1

### DIFF
--- a/lib/ft8_native/ft8_lib/ft8/decode.c
+++ b/lib/ft8_native/ft8_lib/ft8/decode.c
@@ -3,6 +3,7 @@
 #include "crc.h"
 #include "ldpc.h"
 
+#include <stddef.h>
 #include <stdbool.h>
 #include <math.h>
 


### PR DESCRIPTION
The `build-ft8` target is failing with `../ft8_lib/ft8/decode.c:354:20: error: use of undeclared identifier 'NULL'`. This PR fixes that by including the `stddef.h` headers.

```10:06:56 [mhobbs@mobius: (master) ~/src/external/POTACAT> npm install && npm run build-ft8 && npm run dist:mac && open dist/

up to date, audited 490 packages in 3s

85 packages are looking for funding
  run `npm fund` for details

13 vulnerabilities (4 moderate, 9 high)

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force

Run `npm audit` for details.

> potacat@1.8.15 build-ft8
> cd lib/ft8_native && node-gyp rebuild

gyp info it worked if it ends with ok
gyp info using node-gyp@11.5.0
gyp info using node@24.14.0 | darwin | x64
(node:21223) [DEP0169] DeprecationWarning: `url.parse()` behavior is not standardized and prone to errors that have security implications. Use the WHATWG URL API instead. CVEs are not issued for `url.parse()` vulnerabilities.
(Use `node --trace-deprecation ...` to show where the warning was created)
gyp info find Python using Python version 3.9.6 found at "/Library/Developer/CommandLineTools/usr/bin/python3"

gyp info spawn /Library/Developer/CommandLineTools/usr/bin/python3
gyp info spawn args [
gyp info spawn args '/Users/mhobbs/src/external/POTACAT/node_modules/node-gyp/gyp/gyp_main.py',
gyp info spawn args 'binding.gyp',
gyp info spawn args '-f',
gyp info spawn args 'make',
gyp info spawn args '-I',
gyp info spawn args '/Users/mhobbs/src/external/POTACAT/lib/ft8_native/build/config.gypi',
gyp info spawn args '-I',
gyp info spawn args '/Users/mhobbs/src/external/POTACAT/node_modules/node-gyp/addon.gypi',
gyp info spawn args '-I',
gyp info spawn args '/Users/mhobbs/Library/Caches/node-gyp/24.14.0/include/node/common.gypi',
gyp info spawn args '-Dlibrary=shared_library',
gyp info spawn args '-Dvisibility=default',
gyp info spawn args '-Dnode_root_dir=/Users/mhobbs/Library/Caches/node-gyp/24.14.0',
gyp info spawn args '-Dnode_gyp_dir=/Users/mhobbs/src/external/POTACAT/node_modules/node-gyp',
gyp info spawn args '-Dnode_lib_file=/Users/mhobbs/Library/Caches/node-gyp/24.14.0/<(target_arch)/node.lib',
gyp info spawn args '-Dmodule_root_dir=/Users/mhobbs/src/external/POTACAT/lib/ft8_native',
gyp info spawn args '-Dnode_engine=v8',
gyp info spawn args '--depth=.',
gyp info spawn args '--no-parallel',
gyp info spawn args '--generator-output',
gyp info spawn args 'build',
gyp info spawn args '-Goutput_dir=.'
gyp info spawn args ]
gyp info spawn make
gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
  CC(target) Release/obj.target/ft8_native/ft8_addon.o
../ft8_addon.c:170:12: warning: unused variable 'byte_length' [-Wunused-variable]
  170 |     size_t byte_length;
      |            ^~~~~~~~~~~
1 warning generated.
  CC(target) Release/obj.target/ft8_native/ft8_lib/ft8/constants.o
  CC(target) Release/obj.target/ft8_native/ft8_lib/ft8/crc.o
  CC(target) Release/obj.target/ft8_native/ft8_lib/ft8/decode.o
../ft8_lib/ft8/decode.c:329:62: error: use of undeclared identifier 'NULL'
  329 |     return ftx_decode_candidate_ap(wf, cand, max_iterations, NULL, NULL, message, status);
      |                                                              ^~~~
../ft8_lib/ft8/decode.c:329:68: error: use of undeclared identifier 'NULL'
  329 |     return ftx_decode_candidate_ap(wf, cand, max_iterations, NULL, NULL, message, status);
      |                                                                    ^~~~
../ft8_lib/ft8/decode.c:354:20: error: use of undeclared identifier 'NULL'
  354 |     if (ap_mask != NULL)
      |                    ^~~~
3 errors generated.
make: *** [Release/obj.target/ft8_native/ft8_lib/ft8/decode.o] Error 1
gyp ERR! build error
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack at ChildProcess.<anonymous> (/Users/mhobbs/src/external/POTACAT/node_modules/node-gyp/lib/build.js:219:23)
gyp ERR! System Darwin 25.5.0
gyp ERR! command "/Users/mhobbs/.nvm/versions/node/v24.14.0/bin/node" "/Users/mhobbs/src/external/POTACAT/node_modules/.bin/node-gyp" "rebuild"
gyp ERR! cwd /Users/mhobbs/src/external/POTACAT/lib/ft8_native
gyp ERR! node -v v24.14.0
gyp ERR! node-gyp -v v11.5.0
gyp ERR! not ok```