### PR TITLE
Activate ECHOCAT Google Play link (Android live)

### DIFF
--- a/renderer/index.html
+++ b/renderer/index.html
@@ -3139,12 +3139,12 @@
               <img class="settings-echocat-badge-img settings-echocat-badge-img-appstore"
                    src="../assets/app-store-badge.svg" alt="Download on the App Store">
             </a>
-            <span class="settings-echocat-badge-link settings-echocat-badge-disabled" aria-disabled="true"
-                  aria-label="ECHOCAT for Android coming soon">
+            <a class="settings-echocat-badge-link" data-external="1"
+               href="https://play.google.com/store/apps/details?id=co.cmox.echocat"
+               aria-label="Get ECHOCAT on Google Play">
               <img class="settings-echocat-badge-img settings-echocat-badge-img-play"
                    src="../assets/google-play-badge.png" alt="Get it on Google Play">
-              <span class="settings-echocat-badge-overlay">Coming Soon</span>
-            </span>
+            </a>
           </div>
         </div>
         <div class="settings-footer-right">


### PR DESCRIPTION
The ECHOCAT Android app is live on Google Play. This turns the Settings footer's "Coming Soon" Google Play badge into a real link.

- Swaps the disabled `<span>` for an `<a data-external="1">` to `https://play.google.com/store/apps/details?id=co.cmox.echocat`, mirroring the existing App Store badge (so it opens in the external browser).
- Removes the "Coming Soon" overlay. Only `index.html` carried this badge — no other view to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)