### PR TITLE
Flex: seamless SmartSDR/AetherSDR interchange + solo audio + Rig-settings fixes

### DIFF
--- a/lib/smartsdr.js
+++ b/lib/smartsdr.js
@@ -101,8 +101,13 @@ class SmartSdrClient extends EventEmitter {
    *  CAT-status pill key off; `guiReady` alone is too strict for bound mode
    *  (AetherSDR / SmartSDR-Win running). */
   get canTune() {
-    if (!this.connected || this._ourSliceIndex == null) return false;
-    if (this._guiMode === 'self')  return this._guiReady;
+    if (!this.connected) return false;
+    // Self-host: need our `client gui` acked AND the radio's restored slice found.
+    if (this._guiMode === 'self')  return this._guiReady && this._ourSliceIndex != null;
+    // Bound: ride the host's slice. If the host never advertised it (no active=1
+    // and no in_use=1 — e.g. an AetherSDR build that's stingy with slice status),
+    // still allow tuning; the tune/audio paths default to slice 0 rather than
+    // refusing every QSY.
     if (this._guiMode === 'bound') return true;
     return false;
   }
@@ -115,6 +120,14 @@ class SmartSdrClient extends EventEmitter {
    *  when SmartSDR is open, so it owns transmit (TX works open-or-closed). A
    *  `client gui` rejection falls back to bound. False = ride along (bound). */
   setMultiflex(on) { this._multiflex = !!on; }
+
+  /** Single-GUI-slot handoff: when true, POTACAT YIELDS the GUI slot to a
+   *  launching external GUI client (SmartSDR/AetherSDR) — it waits for that
+   *  client to register and then binds, instead of re-grabbing the slot itself.
+   *  Re-grabbing is exactly what locks SmartSDR out ("In use: POTACAT"). The
+   *  caller (main.js handoff) sets this when the radio has multiFlex disabled
+   *  and only one GUI client can hold the slot at a time. */
+  setYieldToExternal(on) { this._yieldToExternal = !!on; }
 
   setNeedsCw(needs) {
     this._needsCw = !!needs;
@@ -235,9 +248,21 @@ class SmartSdrClient extends EventEmitter {
     this._selfHostTimer = null;
     if (!this.connected || this._guiMode !== 'none') return;
     const haveExternal = this._discoveredGuiClients.length > 0;
-    if (!this._multiflex && haveExternal) {
+    // Ride along (bound) when (a) multiFlex is off and a GUI client is open, or
+    // (b) we've been told to YIELD the slot to a launching SmartSDR/AetherSDR.
+    if (haveExternal && (!this._multiflex || this._yieldToExternal)) {
       this._guiMode = 'bound';
       this.emit('gui-mode', 'bound'); // main.js starts the audio client on this
+      return;
+    }
+    // Yielding, but the external GUI client hasn't registered on the radio yet
+    // (it can take several seconds, longer than this grace window). Do NOT grab
+    // the slot — that locks SmartSDR out ("In use: POTACAT"). Keep waiting and
+    // bind the moment it appears. main.js clears the yield + reconnects to
+    // self-host when the 5002 CAT shim drops (SmartSDR actually closed).
+    if (this._yieldToExternal && !haveExternal) {
+      console.log('[SmartSDR] Yielding the GUI slot — waiting for SmartSDR/AetherSDR to register, then will bind…');
+      this._selfHostTimer = setTimeout(() => this._promoteOrBind(), 700);
       return;
     }
     console.log(haveExternal
@@ -474,7 +499,13 @@ class SmartSdrClient extends EventEmitter {
       const handleHex = handleMatch ? handleMatch[1].toUpperCase() : null;
       const isOurHandle = handleHex && (this._ownHandles.has(handleHex) ||
         (this._clientHandle && handleHex === this._clientHandle.toUpperCase()));
-      const isSelf = (clientId === this._persistentId) || isPotacat || isOurHandle;
+      // A real bindable GUI client always has a UUID. client_id=0 (or empty) is
+      // a zombie — the radio's placeholder for a GUI registration that's being
+      // torn down, almost always OUR OWN just-released slot after a handoff
+      // reconnect (new instance → no _ownHandles memory → the UUID/handle checks
+      // miss it). Binding to it routes audio to a corpse; treat it as self/skip.
+      const isZombie = !clientId || clientId === '0' || clientId === '0x0';
+      const isSelf = isZombie || (clientId === this._persistentId) || isPotacat || isOurHandle;
       if (isSelf && handleHex) this._ownHandles.add(handleHex); // remember the ghost's handle too
       if (!isSelf && !this._discoveredGuiClients.includes(clientId)) {
         this._discoveredGuiClients.push(clientId);
@@ -521,9 +552,19 @@ class SmartSdrClient extends EventEmitter {
     // _ourSliceIndex stayed null in bound mode and tunes had nowhere to go.
     if (this._guiMode === 'bound') {
       const active = get('active');
+      const inUse = get('in_use');
       if (active === '1' && this._ourSliceIndex !== idx) {
+        // Strongest signal: the host flags exactly one slice active. Always honor.
         this._ourSliceIndex = idx;
         console.log(`[SmartSDR] Bound mode: following active slice ${idx} (index ${get('index_letter') || '?'})`);
+        this.emit('slice-ready', { index: idx });
+      } else if (this._ourSliceIndex == null && inUse === '1') {
+        // Fallback: some GUI clients don't advertise active=1 (AetherSDR 26.6.3 —
+        // K3SBP 2026-06-26: _ourSliceIndex stayed null → canTune false → every
+        // tune "ignored"). Adopt the first in-use slice so we have a tune target;
+        // a later active=1 line upgrades the choice.
+        this._ourSliceIndex = idx;
+        console.log(`[SmartSDR] Bound mode: following in-use slice ${idx} (host sent no active flag)`);
         this.emit('slice-ready', { index: idx });
       }
     }
@@ -782,6 +823,22 @@ class SmartSdrClient extends EventEmitter {
    *  Per-output `mixer headphone/lineout mute` was accepted but did NOT
    *  silence the front-panel speaker (see scripts/probe-flex-audio.js); the
    *  per-slice audio_mute sits upstream of all three outputs. */
+  /** Set the slice's monitor AF level (0–100, SmartSDR field `audio_level`) —
+   *  the level of the radio's onboard speaker / headphone / lineout. The DAX RX
+   *  tap is full-scale and independent of this, so audio_level=0 should silence
+   *  the PHYSICAL speaker while DAX RX (POTACAT's PC monitor + JTCAT/SSTV
+   *  decoders) keeps full audio. We use this instead of audio_mute in solo Flex
+   *  Direct because on 4.2.x audio_mute=1 ALSO kills the DAX feed (K3SBP
+   *  2026-06-26: muting the slice silenced the PC monitor too), but the operator
+   *  still wants the band on the computer without the radio's own speaker
+   *  blaring (no front-panel volume on the 8600 to turn it down).
+   *  NOTE: the field is `audio_level`, NOT `audio_gain` — the radio rejects
+   *  audio_gain as "Bad field" on the 1.4.0.0 API. */
+  setSliceAudioLevel(idx, level) {
+    const n = Math.max(0, Math.min(100, parseInt(level, 10) || 0));
+    this._send(`slice set ${idx} audio_level=${n}`);
+  }
+
   setOnboardAudioMute(idx, mute) {
     this._send(`slice set ${idx} audio_mute=${mute ? 1 : 0}`);
   }

--- a/lib/smartsdr.js
+++ b/lib/smartsdr.js
@@ -168,6 +168,7 @@ class SmartSdrClient extends EventEmitter {
       this._guiReady = false;
       this._guiSeq = null;
       this._ourSliceIndex = null;
+      this._yieldDeadline = null; // fresh yield window per connect (intent survives)
 
       // Subscribe to client updates so we can discover GUI clients for binding
       this._send('sub client all');
@@ -216,10 +217,32 @@ class SmartSdrClient extends EventEmitter {
 
     sock.on('close', () => {
       const wasConnected = this.connected;
+      // Were we the active GUI head? disconnect() resets _guiMode/_guiReady
+      // BEFORE closing the socket, so this is only true for a RADIO-side close
+      // (a kick), never our own teardown.
+      const wasGuiHead = this._guiMode === 'self' && this._guiReady;
       this.connected = false;
       this._sock = null;
       this._cwBound = false;
       if (wasConnected) this.emit('disconnected');
+      // Kicked off while we were the GUI head: on a single-GUI-slot Flex that
+      // means another GUI client (AetherSDR / SmartSDR / Maestro) is taking the
+      // slot — AetherSDR does this when you evict POTACAT from its station
+      // dialog. Reconnect FAST in yield mode and bind to them instead of
+      // re-grabbing the slot (which would fight or lock them out). The yield
+      // times out in _promoteOrBind and self-hosts if nobody appears, so a plain
+      // network blip still recovers.
+      if (wasConnected && wasGuiHead && this._host) {
+        this._yieldToExternal = true;
+        this._yieldDeadline = null; // fresh window, started in _promoteOrBind
+        this._connectFailures = 0;
+        console.log('[SmartSDR] Kicked off the radio while GUI head — a client is taking over; reconnecting to bind…');
+        this._reconnectTimer = setTimeout(() => {
+          this._reconnectTimer = null;
+          if (!this.connected && this._host) this._doConnect();
+        }, 800);
+        return;
+      }
       this._scheduleReconnect();
     });
 
@@ -251,6 +274,7 @@ class SmartSdrClient extends EventEmitter {
     // Ride along (bound) when (a) multiFlex is off and a GUI client is open, or
     // (b) we've been told to YIELD the slot to a launching SmartSDR/AetherSDR.
     if (haveExternal && (!this._multiflex || this._yieldToExternal)) {
+      this._yieldDeadline = null;
       this._guiMode = 'bound';
       this.emit('gui-mode', 'bound'); // main.js starts the audio client on this
       return;
@@ -259,11 +283,22 @@ class SmartSdrClient extends EventEmitter {
     // (it can take several seconds, longer than this grace window). Do NOT grab
     // the slot — that locks SmartSDR out ("In use: POTACAT"). Keep waiting and
     // bind the moment it appears. main.js clears the yield + reconnects to
-    // self-host when the 5002 CAT shim drops (SmartSDR actually closed).
+    // self-host when the 5002 CAT shim drops (SmartSDR actually closed). But
+    // TIME OUT: if we were kicked by a plain network blip (not a real handoff),
+    // no external GUI will ever appear — fall back to self-hosting so the radio
+    // doesn't stay uncontrollable.
     if (this._yieldToExternal && !haveExternal) {
-      console.log('[SmartSDR] Yielding the GUI slot — waiting for SmartSDR/AetherSDR to register, then will bind…');
-      this._selfHostTimer = setTimeout(() => this._promoteOrBind(), 700);
-      return;
+      if (this._yieldDeadline == null) this._yieldDeadline = Date.now() + 10000;
+      if (Date.now() >= this._yieldDeadline) {
+        console.log('[SmartSDR] Yield timed out — no external GUI registered; self-hosting.');
+        this._yieldToExternal = false;
+        this._yieldDeadline = null;
+        // fall through to self-host below
+      } else {
+        console.log('[SmartSDR] Yielding the GUI slot — waiting for SmartSDR/AetherSDR to register, then will bind…');
+        this._selfHostTimer = setTimeout(() => this._promoteOrBind(), 700);
+        return;
+      }
     }
     console.log(haveExternal
       ? '[SmartSDR] Registering POTACAT as an independent GUI client (multiFlex — alongside the open SmartSDR/AetherSDR)'
@@ -516,6 +551,21 @@ class SmartSdrClient extends EventEmitter {
         } else {
           console.log(`[SmartSDR] Discovered GUI client_id: ${clientId} (total: ${this._discoveredGuiClients.length})`);
         }
+      }
+    }
+
+    // Host GUI client left. When the client we're BOUND to disconnects, the
+    // radio sends `S<h>|client 0x<HANDLE> disconnected` (or connected=0) and its
+    // slice vanishes — every tune then errors "Invalid slice receiver". For
+    // SmartSDR-Win the 5002 shim drop signals this; AetherSDR has no shim, so we
+    // detect it here and reclaim. Only fires in bound mode for OUR host's handle.
+    if (this._guiMode === 'bound' && handleMatch && this._guiClientHandle) {
+      const h = handleMatch[1].toUpperCase();
+      const rest = (line.split(/\|client\s+0x[0-9A-Fa-f]+/)[1] || '');
+      const left = /(?:^|\s)disconnected(?:\s|$)/.test(rest) || /connected=0\b/.test(rest);
+      if (left && h === this._guiClientHandle.toUpperCase()) {
+        console.log(`[SmartSDR] Bound host GUI client (0x${h}) disconnected — reclaiming the radio.`);
+        this.emit('gui-client-left', { handle: h });
       }
     }
   }

--- a/main.js
+++ b/main.js
@@ -15927,6 +15927,28 @@ function migrateRigSettings(s) {
     }
     if (changed) saveSettings(s);
   }
+  // Self-heal Flex rigs whose SmartSDR-Win CAT shim port got corrupted by an
+  // earlier duplicate-id bug: the Rig form built catTarget with port 0-3 (the
+  // 0-3 slice index) instead of 5002-5005, which also made the rig render as a
+  // generic IP-CAT radio and killed the SmartSDR handoff. A Flex rig is the one
+  // with flexApiHost set; if its localhost CAT target isn't a valid shim port,
+  // rebuild it from flexSlice (A=5002 … D=5005). Custom/remote CAT is left alone.
+  if (Array.isArray(s.rigs) && s.rigs.length) {
+    let healed = false;
+    for (const r of s.rigs) {
+      if (!r || !r.flexApiHost) continue; // only Flex rigs
+      const t = r.catTarget;
+      const localhostCat = !t || (t.type === 'tcp' && (t.host === '127.0.0.1' || !t.host));
+      const validShim = t && t.type === 'tcp' && [5002, 5003, 5004, 5005].includes(t.port);
+      if (localhostCat && !validShim) {
+        const slice = (typeof r.flexSlice === 'number' && r.flexSlice >= 0 && r.flexSlice <= 3) ? r.flexSlice : 0;
+        r.catTarget = { type: 'tcp', host: '127.0.0.1', port: 5002 + slice };
+        healed = true;
+        console.log(`[flex-migrate] repaired rig "${r.name || r.id}" CAT target → 127.0.0.1:${5002 + slice}`);
+      }
+    }
+    if (healed) saveSettings(s);
+  }
 }
 
 // --- FlexRadio UDP discovery ----------------------------------------------

--- a/main.js
+++ b/main.js
@@ -6734,6 +6734,10 @@ function connectSmartSdr() {
   // multiFlex: register POTACAT as its own GUI client even when SmartSDR is
   // open, so it owns transmit. Default on; flexMultiflex=false rides along.
   smartSdr.setMultiflex(settings.flexMultiflex !== false);
+  // Single-GUI-slot handoff: when SmartSDR/AetherSDR is launching, yield the
+  // slot and bind instead of re-grabbing it (which locks the GUI client out
+  // with "In use: POTACAT"). Set by checkFlexHandoff; survives the reconnect.
+  smartSdr.setYieldToExternal(_flexYieldToExternal);
   // Tell SmartSDR whether CW keyer needs GUI auth
   smartSdr.setNeedsCw(!!(settings.enableCwKeyer || (settings.enableRemote && settings.remoteCwEnabled)));
   // Bind to GUI client for ECHOCAT rig controls (ATU, etc.)
@@ -6782,18 +6786,26 @@ function connectSmartSdr() {
       _flexDaxChannel = chooseFlexDaxChannel(index);
       const ch = _flexDaxChannel;
       smartSdr.setSliceDax(index, ch);
-      // Onboard-speaker mute. SmartSDR-less self mode: audio_mute is independent
-      // of the DAX tap, so we mute the radio's speaker while DAX RX keeps
-      // flowing (default; flexOnboardSpeaker overrides). BUT in multiFlex (a 2nd
-      // client alongside SmartSDR on 4.2.x), the DAX feed is taken FROM the
-      // slice monitor mix — so audio_mute=1 ALSO silences DAX → no RX. Confirmed
-      // empirically (K3SBP 2026-06-26): muted = 0 decodes, unmuted = decodes. So
-      // in multiFlex we must leave the slice UNMUTED; the cost is the radio's
-      // speaker plays the slice audio (turn down the radio's volume to quiet it).
+      // Speaker vs DAX. On this radio (4.2.x) audio_mute=1 ALSO kills the DAX RX
+      // tap — it's taken from the slice monitor mix — so muting silences the PC
+      // monitor + JTCAT/SSTV decoders too, not just the radio's speaker (K3SBP
+      // 2026-06-26). So NEVER mute in Flex Direct: keep audio_mute=0 so DAX
+      // always flows, and control the PHYSICAL speaker with audio_gain instead
+      // (DAX is full-scale, independent of the slice AF gain). Default = speaker
+      // silenced (gain=0) so the operator listens on the PC without the radio's
+      // own speaker blaring (the 8600 has no front-panel volume to turn down);
+      // flexOnboardSpeaker=true plays the band on the radio's speaker. multiFlex
+      // leaves the host GUI client's gain alone — we only ensure it's unmuted.
       const _multiflexActive = !!(smartSdr._discoveredGuiClients && smartSdr._discoveredGuiClients.length > 0);
-      const onboard = !!settings.flexOnboardSpeaker || _multiflexActive;
-      smartSdr.setOnboardAudioMute(index, !onboard);
-      sendCatLog(`Flex Direct: radio speaker ${onboard ? 'ON' : 'muted'} (slice ${index} audio_mute=${onboard ? 0 : 1})${_multiflexActive ? ' [multiFlex: must stay unmuted for DAX RX]' : ''}`);
+      smartSdr.setOnboardAudioMute(index, false);
+      if (_multiflexActive) {
+        sendCatLog(`Flex Direct: slice ${index} unmuted [multiFlex: host GUI owns speaker/gain]`);
+      } else {
+        const wantSpeaker = settings.flexOnboardSpeaker === true;
+        const level = wantSpeaker ? (parseInt(settings.flexSpeakerGain, 10) || 50) : 0;
+        smartSdr.setSliceAudioLevel(index, level);
+        sendCatLog(`Flex Direct: radio speaker ${wantSpeaker ? `ON (audio_level=${level})` : 'silenced (audio_level=0) — DAX/PC audio still live'} (slice ${index})`);
+      }
     } else {
       // Bound mode: the host GUI client (SmartSDR-Win / AetherSDR) already
       // configured DAX; we're just following its active slice. The UI's CAT
@@ -6878,22 +6890,36 @@ function disconnectSmartSdr() {
 // When that contradicts smartSdr's current role, reconnect it so the
 // grace-window discovery (_promoteOrBind) re-decides self-host vs. bound.
 let _lastCatUpForHandoff = false;
+// True while POTACAT must yield the single GUI slot to a running SmartSDR/
+// AetherSDR (multiFlex off). connectSmartSdr() reads it; the handoff sets it.
+let _flexYieldToExternal = false;
+let _flexReclaimTimer = null; // settle timer before reclaiming the radio on close
 function checkFlexHandoff(catUp) {
   if (catUp === _lastCatUpForHandoff) return; // edge-triggered only
   _lastCatUpForHandoff = catUp;
+  // SmartSDR came (back) up while a reclaim was pending — cancel it; stay bound.
+  if (catUp && _flexReclaimTimer) { clearTimeout(_flexReclaimTimer); _flexReclaimTimer = null; }
   if (!smartSdr || !smartSdr.connected) return;
   if (!settings.catTarget || settings.catTarget.type !== 'tcp') return; // Flex only
   const multiflex = settings.flexMultiflex !== false;
   if (catUp && smartSdr.guiReady && !multiflex) {
-    // Legacy (multiFlex off): SmartSDR-Win came up while self-hosting — hand
-    // off so POTACAT follows SmartSDR's slice (bound) instead of its own.
-    sendCatLog('Flex Direct: SmartSDR detected — handing off (POTACAT will follow SmartSDR).');
+    // multiFlex off: SmartSDR-Win is launching while POTACAT holds the single
+    // GUI slot. Reconnect in YIELD mode so POTACAT releases the slot and waits
+    // to bind — instead of re-grabbing it after the discovery timeout, which is
+    // what was locking SmartSDR out ("In use: POTACAT").
+    sendCatLog('Flex Direct: SmartSDR detected — releasing the GUI slot so it can open; POTACAT will bind and follow it.');
+    _flexYieldToExternal = true;
     connectSmartSdr();
-  } else if (!catUp && smartSdr.mode === 'bound') {
-    // SmartSDR-Win closed while bound (multiFlex off, or the radio refused a
-    // 2nd client) — reclaim the radio by self-hosting again.
-    sendCatLog('Flex Direct: SmartSDR closed — POTACAT resuming as the GUI client.');
-    connectSmartSdr();
+  } else if (!catUp && (smartSdr.mode === 'bound' || _flexYieldToExternal)) {
+    // SmartSDR-Win closed (while bound, or while we were still yielding because
+    // it never finished registering) — stop yielding and reclaim the radio.
+    // DELAY the reconnect: the radio drops SmartSDR's GUI registration a beat
+    // after its 5002 shim dies, and reconnecting instantly catches that stale
+    // client and re-binds to a corpse instead of self-hosting. Let it clear.
+    sendCatLog('Flex Direct: SmartSDR closed — reclaiming the radio as GUI client…');
+    _flexYieldToExternal = false;
+    if (_flexReclaimTimer) clearTimeout(_flexReclaimTimer);
+    _flexReclaimTimer = setTimeout(() => { _flexReclaimTimer = null; connectSmartSdr(); }, 2000);
   }
   // multiFlex + SmartSDR opened while self-hosting: nothing to do — POTACAT
   // stays its own gui client alongside SmartSDR (no reconnect, no audio glitch).
@@ -22167,8 +22193,17 @@ app.whenReady().then(() => {
     // the slice POTACAT owns without a reconnect; bound mode leaves the
     // host GUI client's audio routing alone.
     if (flexOnboardSpeakerChanged && smartSdr && smartSdr.mode === 'self' && smartSdr.ourSliceIndex != null) {
-      smartSdr.setOnboardAudioMute(smartSdr.ourSliceIndex, !settings.flexOnboardSpeaker);
-      sendCatLog(`Flex Direct: radio speaker ${settings.flexOnboardSpeaker ? 'ON' : 'muted'} (live)`);
+      // Mirror the slice-ready policy: never mute (that kills DAX too); control
+      // the physical speaker with audio_gain. Only in solo — multiFlex leaves the
+      // host GUI client's gain alone.
+      const _multiflexActive = !!(smartSdr._discoveredGuiClients && smartSdr._discoveredGuiClients.length > 0);
+      smartSdr.setOnboardAudioMute(smartSdr.ourSliceIndex, false);
+      if (!_multiflexActive) {
+        const wantSpeaker = settings.flexOnboardSpeaker === true;
+        const level = wantSpeaker ? (parseInt(settings.flexSpeakerGain, 10) || 50) : 0;
+        smartSdr.setSliceAudioLevel(smartSdr.ourSliceIndex, level);
+        sendCatLog(`Flex Direct: radio speaker ${wantSpeaker ? `ON (audio_level=${level})` : 'silenced (audio_level=0) — DAX/PC audio still live'} (live)`);
+      }
     }
 
     // DAX-free audio path: start / stop the dedicated non-GUI audio

--- a/main.js
+++ b/main.js
@@ -6708,11 +6708,32 @@ function connectSmartSdr() {
   // they're captured in the mobile diagnostic snapshot, not just console.log.
   smartSdr.on('cmd-error', ({ seq, status, line }) => {
     sendCatLog(`[SmartSDR] cmd error: R${seq}|${(status >>> 0).toString(16)}|${line}`);
+    // Backup to the client-left detector: when bound to an external GUI client
+    // whose slice has vanished (it closed — AetherSDR gives no 5002 shim drop),
+    // our tunes error "Invalid slice receiver". That's definitive — reclaim the
+    // radio. Debounced (shared timer) + guarded to bound mode so a startup
+    // transient in self/none mode never triggers it.
+    if (smartSdr && smartSdr.mode === 'bound' && /Invalid slice receiver/i.test(line || '')) {
+      reclaimFlexRadio('bound GUI client gone (slice invalid)');
+    }
   });
   smartSdr.on('disconnected', () => {
     sendCatLog('SmartSDR API disconnected — rig controls (ATU/filter/gain) unavailable');
     // Flex Direct: with no port-5002 CAT either, the radio is now uncontrollable.
     if (!cat || !cat.connected) sendCatStatus({ connected: false });
+    // Recycle the audio client. This fires only on an UNEXPECTED drop (a kick —
+    // intentional disconnect() flips `connected` false before the socket closes,
+    // so it never emits 'disconnected'). After a kick the client auto-reconnects
+    // and re-binds (e.g. to AetherSDR); the old audio client is still bound to
+    // our dead client_id and startSmartSdrAudio() is idempotent, so tear it down
+    // here and let the reconnect's gui-mode/gui-ready start it on the new client.
+    stopSmartSdrAudio();
+  });
+  // The external GUI client we were bound to left the radio. For SmartSDR-Win
+  // the 5002 shim drop handles this; AetherSDR has no shim, so smartsdr.js
+  // detects its client-disconnect status and emits this. Reclaim → self-host.
+  smartSdr.on('gui-client-left', () => {
+    if (smartSdr && smartSdr.mode === 'bound') reclaimFlexRadio('bound GUI client (AetherSDR) closed');
   });
   smartSdr.on('give-up', ({ host, attempts }) => {
     const isLocal = host === '127.0.0.1' || host === 'localhost';
@@ -6894,6 +6915,17 @@ let _lastCatUpForHandoff = false;
 // AetherSDR (multiFlex off). connectSmartSdr() reads it; the handoff sets it.
 let _flexYieldToExternal = false;
 let _flexReclaimTimer = null; // settle timer before reclaiming the radio on close
+// Reclaim the radio (self-host) after the bound GUI client goes away. DELAY the
+// reconnect so the radio drops the host's stale GUI registration first — an
+// instant reconnect catches the corpse and re-binds to it instead of self-
+// hosting. Shared by the SmartSDR 5002-shim-drop path and the AetherSDR
+// client-left path (which can both fire) so they coalesce into one reconnect.
+function reclaimFlexRadio(reason) {
+  _flexYieldToExternal = false;
+  if (_flexReclaimTimer) clearTimeout(_flexReclaimTimer);
+  sendCatLog(`Flex Direct: ${reason} — reclaiming the radio as GUI client…`);
+  _flexReclaimTimer = setTimeout(() => { _flexReclaimTimer = null; connectSmartSdr(); }, 2000);
+}
 function checkFlexHandoff(catUp) {
   if (catUp === _lastCatUpForHandoff) return; // edge-triggered only
   _lastCatUpForHandoff = catUp;
@@ -6913,13 +6945,7 @@ function checkFlexHandoff(catUp) {
   } else if (!catUp && (smartSdr.mode === 'bound' || _flexYieldToExternal)) {
     // SmartSDR-Win closed (while bound, or while we were still yielding because
     // it never finished registering) — stop yielding and reclaim the radio.
-    // DELAY the reconnect: the radio drops SmartSDR's GUI registration a beat
-    // after its 5002 shim dies, and reconnecting instantly catches that stale
-    // client and re-binds to a corpse instead of self-hosting. Let it clear.
-    sendCatLog('Flex Direct: SmartSDR closed — reclaiming the radio as GUI client…');
-    _flexYieldToExternal = false;
-    if (_flexReclaimTimer) clearTimeout(_flexReclaimTimer);
-    _flexReclaimTimer = setTimeout(() => { _flexReclaimTimer = null; connectSmartSdr(); }, 2000);
+    reclaimFlexRadio('SmartSDR closed');
   }
   // multiFlex + SmartSDR opened while self-hosting: nothing to do — POTACAT
   // stays its own gui client alongside SmartSDR (no reconnect, no audio glitch).

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -13823,7 +13823,7 @@ async function openSettingsDialog(tab) {
   }
   if (setFlexMultiflex) setFlexMultiflex.checked = s.flexMultiflex !== false; // default on
   if (setFlexOnboardSpeaker) {
-    setFlexOnboardSpeaker.checked = !!s.flexOnboardSpeaker;
+    setFlexOnboardSpeaker.checked = s.flexOnboardSpeaker === true; // default off: quiet radio, listen on the PC (DAX still flows)
   }
   // TX EQ — load saved state into the Settings dialog. Live updates go
   // through window.api.setTxEq() so toggling the checkbox / dropdown

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -1875,7 +1875,10 @@ async function populateRadioSection(currentTarget) {
       [5002, 5003, 5004, 5005].includes(currentTarget.port);
     if (isFlexSlice) {
       setRadioType('flex');
-      setFlexSlice.value = String(currentTarget.port);
+      // The slice select holds 0-3 (A-D), not the port — derive it from the
+      // shim port (5002→A …). The authoritative restore from rig.flexSlice runs
+      // right after this; this just keeps the control right for standalone calls.
+      setFlexSlice.value = String(Math.max(0, Math.min(3, (currentTarget.port || 5002) - 5002)));
     } else {
       setRadioType('tcpcat');
       setTcpcatHost.value = currentTarget.host || '127.0.0.1';
@@ -2273,7 +2276,14 @@ function renderRigList(rigs, activeRigId) {
 function buildCatTargetFromForm() {
   const radioType = getSelectedRadioType();
   if (radioType === 'flex') {
-    return { type: 'tcp', host: '127.0.0.1', port: parseInt(setFlexSlice.value, 10) };
+    // POTACAT talks to the radio directly on 4992; this CAT target is the
+    // SmartSDR-Win Kenwood shim (port 5002+slice), used only to DETECT when
+    // SmartSDR-Win is running (the handoff trigger) and as a bound-mode tune
+    // path. Derive it from the chosen slice — A=5002, B=5003, C=5004, D=5005.
+    // (Was read from a now-removed legacy dropdown that collided on the same id
+    // as the slice select, producing a garbage port 0-3.)
+    const slice = parseInt(setFlexSlice.value, 10) || 0; // 0-3
+    return { type: 'tcp', host: '127.0.0.1', port: 5002 + slice };
   } else if (radioType === 'tcpcat') {
     return { type: 'tcp', host: setTcpcatHost.value.trim() || '127.0.0.1', port: parseInt(setTcpcatPort.value, 10) || 5002 };
   } else if (radioType === 'k4network') {
@@ -20233,6 +20243,12 @@ document.getElementById('welcome-rig-save-btn').addEventListener('click', () => 
   const name = document.getElementById('welcome-rig-name').value.trim() || 'My Radio';
   const catTarget = buildWelcomeCatTarget();
   welcomeRig = { id: 'rig_' + Date.now(), name, catTarget };
+  // Keep POTACAT's audio/tune slice in sync with the chosen Flex CAT shim port
+  // (5002→A …) so a non-A pick doesn't leave audio on slice A while CAT targets
+  // another slice.
+  if (catTarget && catTarget.type === 'tcp' && catTarget.port >= 5002 && catTarget.port <= 5005) {
+    welcomeRig.flexSlice = catTarget.port - 5002;
+  }
   showWelcomeRigItem(welcomeRig);
   document.getElementById('welcome-rig-editor').classList.add('hidden');
   document.getElementById('welcome-rig-add-btn').classList.add('hidden');

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -1481,7 +1481,7 @@
         <label style="display:block;margin:10px 0 4px;">Audio source for JTCAT / SSTV:
           <select id="set-audio-source" style="min-width:240px;">
             <option value="dax">Local audio device / DAX</option>
-            <option value="smartsdr">SmartSDR Direct (no DAX program)</option>
+            <option value="smartsdr">Flex Direct &mdash; VITA-49, no DAX program</option>
             <option value="icom-network">Icom Network audio (RS-BA1)</option>
           </select>
         </label>
@@ -1517,13 +1517,13 @@
           </label>
           <span class="help-text" style="display:block;margin-bottom:6px;">Which Flex slice POTACAT uses for receive/transmit audio (DAX). POTACAT keeps this slice on the right DAX channel automatically &mdash; if SmartSDR has it on a different channel (or DAX off), RX goes silent, so POTACAT re-assigns it. Default <b>A</b>.</span>
           <label class="checkbox-label" style="margin-top:10px;">
-            <input type="checkbox" id="set-flex-multiflex" checked> Run as an independent SmartSDR client (multiFlex)
+            <input type="checkbox" id="set-flex-multiflex" checked> Run an independent slice when SmartSDR / AetherSDR is open (multiFlex)
           </label>
-          <span class="help-text" style="display:block;margin-bottom:6px;">On by default. POTACAT registers as its own SmartSDR client so receive <i>and</i> transmit work the same whether SmartSDR is open or not. Requires multiFlex enabled on the radio (8000-series / 6400M / 6600M); if the radio refuses a second client, POTACAT rides along with the open SmartSDR instead (receive works, transmit needs SmartSDR closed). While SmartSDR is open, POTACAT's slice plays on the radio's speaker (DAX needs it unmuted) &mdash; mute the speaker in SmartSDR if you don't want it. SmartSDR-less operation is unaffected.</span>
+          <span class="help-text" style="display:block;margin-bottom:6px;"><b>Checked:</b> POTACAT registers as its own GUI client and keeps a <i>separate</i> slice, so it can transmit while SmartSDR / AetherSDR is open &mdash; but the other app shows its own slice, not the one POTACAT is working. Needs multiFlex enabled on the radio (8000-series / 6400M / 6600M). <b>Unchecked:</b> POTACAT follows the open client's slice (so SmartSDR / AetherSDR shows exactly what you're hunting) and hands off automatically &mdash; self-hosting when no client is open, binding when one opens, reclaiming when it closes; transmit (FT8 / SSTV) still works over DAX. Either way, SmartSDR-less (Flex Direct) operation is unaffected.</span>
           <label class="checkbox-label" style="margin-top:10px;">
             <input type="checkbox" id="set-flex-onboard-speaker"> Play RX audio on the radio's built-in speaker
           </label>
-          <span class="help-text" style="display:block;margin-bottom:6px;">Off by default. When POTACAT runs the radio with no SmartSDR open (Flex Direct), the tuned slice is kept silent on the radio's own speaker (audio_gain=0) so you can listen on the computer (VFO popout speaker button) without the radio blaring. Check this to play the band on the 8400/8600's built-in speaker instead. Either way DAX RX (PC monitor + JTCAT/SSTV) keeps full audio &mdash; POTACAT no longer mutes the slice, which on 4.2.x firmware also killed DAX.</span>
+          <span class="help-text" style="display:block;margin-bottom:6px;">Off by default. When POTACAT runs the radio with no SmartSDR open (Flex Direct), the tuned slice is kept silent on the radio's own speaker (slice audio level 0) so you can listen on the computer (VFO popout speaker button) without the radio blaring. Check this to play the band on the 8400/8600's built-in speaker instead. Either way DAX RX (PC monitor + JTCAT/SSTV) keeps full audio &mdash; POTACAT no longer mutes the slice, which on 4.2.x firmware also killed DAX.</span>
           <label class="checkbox-label" style="margin-top:6px;">
             <input type="checkbox" id="set-smartsdr-spots"> Show spots on the panadapter
           </label>
@@ -1536,18 +1536,6 @@
             </label>
             <span class="help-text" style="display:block;">0 = no limit. Capping reduces audio dropouts on a Flex 6500.</span>
           </div>
-          <details id="flex-advanced" style="margin-top:10px;">
-            <summary>Advanced</summary>
-            <label style="margin-top:8px;">Legacy SmartSDR CAT slice:
-              <select id="set-flex-slice">
-                <option value="5002">Slice A (TCP :5002)</option>
-                <option value="5003">Slice B (TCP :5003)</option>
-                <option value="5004">Slice C (TCP :5004)</option>
-                <option value="5005">Slice D (TCP :5005)</option>
-              </select>
-            </label>
-            <span class="help-text" style="display:block;">POTACAT tunes the radio directly over the API. This routes tuning through SmartSDR-Win's Kenwood CAT shim (TCP 5002&ndash;5005) instead &mdash; a fallback only, and SmartSDR must be running.</span>
-          </details>
           <!-- Per-band antenna selection. Sent to the radio via SmartSDR
                `slice set <N> rxant=ANTx txant=ANTy` immediately before
                every tune. Skipped for bands left blank. Casey 2026-06-09. -->

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -1523,7 +1523,7 @@
           <label class="checkbox-label" style="margin-top:10px;">
             <input type="checkbox" id="set-flex-onboard-speaker"> Play RX audio on the radio's built-in speaker
           </label>
-          <span class="help-text" style="display:block;margin-bottom:6px;">Off by default. When POTACAT runs the radio with no SmartSDR open (Flex Direct), an 8400/8600 plays the tuned slice on its onboard speaker. Leave this off to keep the radio silent while hunting &mdash; JTCAT/SSTV receive audio (DAX) is unaffected either way.</span>
+          <span class="help-text" style="display:block;margin-bottom:6px;">Off by default. When POTACAT runs the radio with no SmartSDR open (Flex Direct), the tuned slice is kept silent on the radio's own speaker (audio_gain=0) so you can listen on the computer (VFO popout speaker button) without the radio blaring. Check this to play the band on the 8400/8600's built-in speaker instead. Either way DAX RX (PC monitor + JTCAT/SSTV) keeps full audio &mdash; POTACAT no longer mutes the slice, which on 4.2.x firmware also killed DAX.</span>
           <label class="checkbox-label" style="margin-top:6px;">
             <input type="checkbox" id="set-smartsdr-spots"> Show spots on the panadapter
           </label>


### PR DESCRIPTION
## Summary
Makes POTACAT and a Flex GUI client (**SmartSDR-Win** or **AetherSDR**) usable interchangeably on a single-GUI-slot radio (multiFlex off): POTACAT self-hosts (Flex Direct) when alone and binds to the open client's slice when one is running, so the client always shows the slice you're working. Also fixes solo Flex Direct audio and a Flex Rig-settings bug.

All flows below were validated live on a FLEX-8600 (firmware 4.2.x / API 1.4.0.0).

## What's included
- **Single-slot handoff (SmartSDR-Win):** yield the GUI slot to a launching SmartSDR instead of re-grabbing it after the discovery timeout (was causing *"In use: POTACAT"*); wait-and-bind, then a 2 s settle before reclaiming on close.
- **Automatic AetherSDR handoff (no 5002 shim):**
  - AetherSDR-first → POTACAT discovers it on 4992 and binds, tuning the slice over the 4992 API.
  - POTACAT-first → evict POTACAT in AetherSDR's station dialog → kick detected → fast rebind (yield with a 10 s timeout so a plain network blip still self-hosts).
  - Close AetherSDR → host client-disconnect detected (+ "Invalid slice receiver" backup) → reclaim → self-host.
- **AetherSDR 26.6.3 slice quirk:** it doesn't flag its slice `active=1`; bound mode now adopts the first `in_use=1` slice and `canTune` no longer refuses in bound mode.
- **Ghost/zombie hardening:** ignore `client_id=0` records so audio binds to the real client, not POTACAT's just-released slot.
- **Solo audio:** never mute the slice (`audio_mute=1` also kills the DAX RX tap on 4.2.x); silence the physical speaker with `audio_level=0` instead (DAX stays full-scale). `flexOnboardSpeaker` off = quiet radio + listen on the PC; on = radio speaker.
- **Rig settings fix:** two controls shared `id="set-flex-slice"`, so the Flex CAT target built with port 0-3 instead of 5002-5005 — re-saving a Flex rig clobbered the SmartSDR handoff port. Derive the shim port from the slice (A=5002 … D=5005), remove the dead legacy dropdown, and **self-heal** corrupted rigs at startup. multiFlex help reworded (mentions AetherSDR + auto-handoff); default unchanged (on).

## Test matrix (all ✅ on hardware)
| Scenario | Result |
|---|---|
| Solo Flex Direct | Quiet radio + PC audio |
| Open SmartSDR while running | Yield → bind, no "In use" |
| Close SmartSDR | Settle → reclaim → self-host |
| AetherSDR first → POTACAT | Binds, tunes via 4992 |
| POTACAT-first → evict in AetherSDR dialog | Kick → rebind |
| Close AetherSDR | Client-left → reclaim → self-host |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
