### PR TITLE
CW: user-addable macros (1-25) + mobile handoff

### DIFF
--- a/docs/mobile-handoff-cw-macros-expandable.md
+++ b/docs/mobile-handoff-cw-macros-expandable.md
@@ -1,0 +1,94 @@
+# Mobile Handoff — expandable CW macros (1–25, like voice macros)
+
+**Audience:** ECHOCAT mobile (iOS) team
+**Desktop status:** shipped. Desktop now lets the operator add/remove CW macros up to 25 (was a fixed 5), using the same `+ Add` / `− Remove last` / `N / 25` UI as voice macros.
+**Protocol:** **unchanged.** `remoteCwMacros` was already a variable-length array and `save-cw-macros` already accepts any length — so there is **no desktop-side work** and nothing to coordinate on the wire. This handoff is purely "let the phone show/edit more than 5."
+
+---
+
+## TL;DR
+
+The desktop CW macro list used to be a hardcoded 5 (`CQ / 599 / 73 / AGN / TU`).
+It's now a user-addable list of **1–25** macros. If the mobile CW macro editor
+hard-caps at 5 (or renders a fixed 5 rows), it will **silently drop macros 6–25**
+that the operator created on the desktop, and won't let the phone add more.
+
+Update the mobile CW macro editor to render **however many macros arrive** and to
+**add/remove up to 25** — mirroring the voice-macro editor that already exists on
+mobile. No protocol changes.
+
+---
+
+## What changed on desktop (for context)
+
+- `renderer/app.js`:
+  - `CW_MACRO_MAX = 25`, `CW_MACRO_DEFAULT_SLOTS = 5`.
+  - Visible row count stored in `localStorage['pota-cat-cw-macro-slots']` (machine-global, same pattern as `pota-cat-voice-macro-slots`).
+  - `renderCwMacroEditor()` now draws `slots` rows + a footer with **`+ Add macro`**, **`− Remove last`** (only when the last row is empty), and an **`N / 25`** counter. Never shows fewer rows than there are populated macros.
+  - `readCwMacroEditor()` reads all rows → `settings.cwMacros` on Settings Save.
+- Runtime macro bar `updateCwMacroBar()` **skips any macro with no label and no text** — empty slots never become buttons. (This was already true; keep the same rule on mobile.)
+- Per-macro shape is unchanged: `{ label: string, text: string }`. `label` is the button caption, ≤ 6 chars; `text` is the CW to send.
+
+---
+
+## Protocol (all unchanged — reference only)
+
+### Desktop → phone (auth-ok handshake)
+```jsonc
+{
+  // …other fields…
+  "remoteCwMacros": [ { "label": "CQ", "text": "CQ CQ CQ DE {MYCALL} {MYCALL} K" }, … ]
+  // now up to 25 entries (was up to 5). May be null if none configured.
+}
+```
+- Source on desktop: `settings.remoteCwMacros || settings.cwMacros || null`
+  (main.js ~8274). Phone-edited macros (`remoteCwMacros`) win; otherwise it falls
+  back to the desktop's own `cwMacros`. **Render the full array length you receive.**
+
+### Phone → desktop (save edits)
+```jsonc
+{ "type": "save-cw-macros", "macros": [ { "label": "…", "text": "…" }, … ] }
+```
+- Desktop handler (main.js ~11396) stores it to `settings.remoteCwMacros`, persists,
+  and re-pushes to all connected clients. **Already accepts variable length** — send
+  the whole list (1–25). Don't trim to 5.
+
+### Phone → desktop (key a macro / cancel)
+```jsonc
+{ "type": "cw-text", "text": "<RAW macro text, e.g. '{call} UR 599 {state} BK'>" }
+{ "type": "cw-cancel-text" }
+```
+- Send the **raw** macro `text` (with `{…}` variables intact). The desktop expands
+  variables and keys the rig via whatever CW backend is active (Flex CW / WinKeyer /
+  DTR / CAT). **Do not expand on the phone** — the desktop has the tuned-spot context.
+
+### Variables (expanded desktop-side)
+`{MYCALL}` · `{call}` (tuned spot callsign) · `{op_firstname}` · `{state}`
+
+---
+
+## Mobile work requested
+
+1. **Remove the 5-macro cap** in the CW macro editor. Allow 1–25 with `+ Add` /
+   `− Remove last` (reuse the voice-macro editor's slot logic; an `N / 25` counter
+   is a nice-to-have for parity).
+2. **Render the full `remoteCwMacros` array** received in auth-ok (could be > 5).
+   **Skip empties** (no `label` and no `text`) so they don't become blank buttons.
+3. **On save**, send the entire variable-length array via `save-cw-macros`.
+4. **Keep `{label, text}` shape and the variable tokens** exactly as above; keep
+   sending raw `text` on `cw-text`.
+
+No desktop or protocol change is needed — the desktop is already emitting and
+accepting variable-length CW macro lists.
+
+---
+
+## Desktop references
+
+- UI / slot model: `renderer/app.js` → `renderCwMacroEditor()`, `loadCwMacroSlots()`,
+  `saveCwMacroSlots()`, `readCwMacroEditor()`, `updateCwMacroBar()`.
+- Handshake field: `main.js` ~8274 (`remoteCwMacros`).
+- Save handler: `main.js` ~11396 (`save-cw-macros`).
+- Key/cancel: `main.js` ~9875 (`cw-text`), ~9871 (`cw-cancel-text`).
+- Voice-macro editor to mirror (already 1–25 on desktop): `renderer/app.js`
+  `renderVoiceMacroEditor()`, `VOICE_MACRO_MAX = 25`.

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -7698,16 +7698,87 @@ const DEFAULT_CW_MACROS = [
   { label: 'AGN', text: 'AGN AGN PSE' },
   { label: 'TU', text: 'TU DE {MYCALL} K' },
 ];
+// User-addable CW macros — mirrors the voice-macro slot model (+/- buttons,
+// capped at 25). The visible row count is stored in localStorage; the macro
+// content is saved to settings.cwMacros on Settings Save.
+const CW_MACRO_MAX = 25;
+const CW_MACRO_DEFAULT_SLOTS = 5; // matches the historical fixed set
+const CW_MACRO_SLOTS_KEY = 'pota-cat-cw-macro-slots';
+function loadCwMacroSlots() {
+  let n = parseInt(localStorage.getItem(CW_MACRO_SLOTS_KEY), 10);
+  if (!Number.isFinite(n)) n = CW_MACRO_DEFAULT_SLOTS;
+  return Math.min(CW_MACRO_MAX, Math.max(1, n));
+}
+function saveCwMacroSlots(n) {
+  n = Math.min(CW_MACRO_MAX, Math.max(1, n));
+  try { localStorage.setItem(CW_MACRO_SLOTS_KEY, String(n)); } catch {}
+  return n;
+}
+// Raw read of the current editor rows (untrimmed) — used to preserve unsaved
+// edits when the +/- buttons re-render.
+function readCwMacroRows() {
+  const labels = cwMacroEditorEl.querySelectorAll('.cw-macro-label');
+  const texts = cwMacroEditorEl.querySelectorAll('.cw-macro-text');
+  const rows = [];
+  labels.forEach((el, i) => rows.push({ label: el.value, text: texts[i] ? texts[i].value : '' }));
+  return rows;
+}
 function renderCwMacroEditor(macros) {
   const list = macros && macros.length ? macros : DEFAULT_CW_MACROS;
+  // Show the saved slot count, but never fewer rows than there are populated
+  // macros (so an imported/larger set isn't hidden).
+  let slots = loadCwMacroSlots();
+  for (let h = CW_MACRO_MAX - 1; h >= 0; h--) {
+    const m = list[h];
+    if (m && (((m.label || '').length) || ((m.text || '').length))) {
+      if (h + 1 > slots) slots = h + 1;
+      break;
+    }
+  }
+  slots = Math.min(CW_MACRO_MAX, Math.max(1, slots));
   cwMacroEditorEl.innerHTML = '';
-  list.forEach((m, i) => {
+  for (let i = 0; i < slots; i++) {
+    const m = list[i] || {};
     const row = document.createElement('div');
     row.style.cssText = 'display:flex;gap:4px;align-items:center;';
     row.innerHTML = `<input type="text" class="cw-macro-label" data-idx="${i}" value="${(m.label || '').replace(/"/g, '&quot;')}" style="width:50px;font-size:11px;padding:2px 4px;" maxlength="6" placeholder="F${i + 1}">` +
       `<input type="text" class="cw-macro-text" data-idx="${i}" value="${(m.text || '').replace(/"/g, '&quot;')}" style="flex:1;font-size:11px;padding:2px 4px;font-family:monospace;" placeholder="CW text...">`;
     cwMacroEditorEl.appendChild(row);
-  });
+  }
+  // Footer: + Add / − Remove last + counter (mirrors the voice-macro editor).
+  const footer = document.createElement('div');
+  footer.style.cssText = 'display:flex;gap:8px;align-items:center;margin-top:4px;';
+  if (slots < CW_MACRO_MAX) {
+    const addBtn = document.createElement('button');
+    addBtn.type = 'button';
+    addBtn.textContent = '+ Add macro';
+    addBtn.title = 'Add another CW macro (up to ' + CW_MACRO_MAX + ')';
+    addBtn.style.cssText = 'font-size:11px;padding:3px 10px;cursor:pointer;';
+    addBtn.addEventListener('click', () => {
+      saveCwMacroSlots(slots + 1);
+      renderCwMacroEditor(readCwMacroRows());
+    });
+    footer.appendChild(addBtn);
+  }
+  const last = list[slots - 1];
+  const lastEmpty = !last || (!(last.label || '').trim() && !(last.text || '').trim());
+  if (slots > 1 && lastEmpty) {
+    const remBtn = document.createElement('button');
+    remBtn.type = 'button';
+    remBtn.textContent = '− Remove last';
+    remBtn.title = 'Hide the last (empty) CW macro';
+    remBtn.style.cssText = 'font-size:11px;padding:3px 10px;cursor:pointer;';
+    remBtn.addEventListener('click', () => {
+      saveCwMacroSlots(slots - 1);
+      renderCwMacroEditor(readCwMacroRows());
+    });
+    footer.appendChild(remBtn);
+  }
+  const counter = document.createElement('span');
+  counter.style.cssText = 'font-size:11px;color:var(--text-dim);margin-left:auto;';
+  counter.textContent = slots + ' / ' + CW_MACRO_MAX;
+  footer.appendChild(counter);
+  cwMacroEditorEl.appendChild(footer);
 }
 function readCwMacroEditor() {
   const labels = cwMacroEditorEl.querySelectorAll('.cw-macro-label');


### PR DESCRIPTION
## Summary
Lets the operator add/remove CW macros up to **25** (was a fixed set of 5), using the same `+ Add macro` / `− Remove last` / `N / 25` UI as voice macros.

## Changes
- `renderer/app.js` — `renderCwMacroEditor()` rewritten to a slot model: `CW_MACRO_MAX = 25`, visible row count in `localStorage['pota-cat-cw-macro-slots']` (default 5), +/- buttons and an `N / 25` counter. Never shows fewer rows than there are populated macros; macro content still saves to `settings.cwMacros`. The runtime macro bar already skips empty macros.
- **No protocol change** — `remoteCwMacros` (auth-ok handshake) and `save-cw-macros` already carry variable-length arrays, so ECHOCAT phone sync scales to 25 for free.
- Adds `docs/mobile-handoff-cw-macros-expandable.md` for the ECHOCAT iOS team (render the full array, allow 1–25, skip empties; wire unchanged).

## Notes
- Per-macro shape unchanged: `{ label, text }`; variables `{MYCALL} {call} {op_firstname} {state}`.
- Mirrors the existing voice-macro editor (`VOICE_MACRO_MAX = 25`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
