### PR TITLE
Fix native JS8 standalone audio startup

### DIFF
--- a/main.js
+++ b/main.js
@@ -9983,6 +9983,15 @@ function stopJs8Spectrum() {
   console.log('[JS8] waterfall spectrum loop stopped');
 }
 
+function startJs8AudioFeed() {
+  if (jtcatPopoutWin && !jtcatPopoutWin.isDestroyed()) return;
+  if (win && !win.isDestroyed()) win.webContents.send('jtcat-start-for-js8');
+}
+
+function stopJs8AudioFeed() {
+  if (win && !win.isDestroyed()) win.webContents.send('jtcat-stop-for-js8');
+}
+
 function stopJtcat() {
   clearJtcatTxFailsafe();
   clearJtcatIcomHardRelease();
@@ -15555,14 +15564,14 @@ function connectRemote() {
   // back on js8-send-result so the phone shows "why not" instead of nothing.
   remoteServer.on('js8-start', ({ reqId } = {}) => {
     markUserActive();
-    if (js8Engine()) { js8PushStatus(); return; }
+    if (js8Engine()) { startJs8AudioFeed(); js8PushStatus(); return; }
     if (!settings.myCallsign) {
       // reqId attributes the failure to the tap — a bare ok:false reads as
       // a session-level error on the phone and cancels a pending send.
       remoteServer.sendJs8SendResult({ ok: false, error: 'Set your callsign in Settings on the desktop first.', reqId });
       return;
     }
-    try { startJtcat('JS8'); } catch (err) {
+    try { startJtcat('JS8'); startJs8AudioFeed(); } catch (err) {
       remoteServer.sendJs8SendResult({ ok: false, error: String((err && err.message) || err), reqId });
     }
   });
@@ -15571,6 +15580,7 @@ function connectRemote() {
     if (!js8Engine()) return;
     js8SetHeartbeat(false);
     stopJtcat();
+    stopJs8AudioFeed();
     js8PushStatus();
   });
   remoteServer.on('js8-heartbeat', ({ enabled, intervalMin }) => {
@@ -24422,6 +24432,7 @@ app.whenReady().then(() => {
       if (win && !win.isDestroyed()) {
         win.webContents.send('jtcat-popout-status', false);
       }
+      if (js8Engine()) startJs8AudioFeed();
       // Popout gone: if an ECHOCAT client is connected, the target SURVIVES —
       // it belongs to the session, not the surface (handoff work item 4; the
       // remote fire path takes over). With no remote client there is nobody
@@ -24581,7 +24592,7 @@ app.whenReady().then(() => {
       // from their device.
       const remoteMaybeUsingJs8 = remoteServer && remoteServer.hasClient && remoteServer.hasClient();
       if (js8Engine() && !remoteMaybeUsingJs8) {
-        try { js8SetHeartbeat(false); stopJtcat(); } catch (err) { sendCatLog('[JS8] stop on close failed: ' + (err.message || err)); }
+        try { js8SetHeartbeat(false); stopJtcat(); stopJs8AudioFeed(); } catch (err) { sendCatLog('[JS8] stop on close failed: ' + (err.message || err)); }
       }
     });
     js8PopoutWin.webContents.on('did-finish-load', () => {
@@ -24606,6 +24617,7 @@ app.whenReady().then(() => {
       // it). No callsign → stay stopped; the bar's Start gives the clear error.
       if (!js8Engine() && settings.myCallsign) {
         try { startJtcat('JS8'); } catch (err) { sendCatLog('[JS8] auto-start on open failed: ' + (err.message || err)); }
+        if (js8Engine()) startJs8AudioFeed();
         js8PushStatus();
       }
     });
@@ -24646,12 +24658,13 @@ app.whenReady().then(() => {
   // in JS8 mode and every audio route, guard, and popout behavior follows.
   ipcMain.handle('js8-start', () => {
     markUserActive();
-    if (js8Engine()) return { ok: true, already: true };
+    if (js8Engine()) { startJs8AudioFeed(); return { ok: true, already: true }; }
     if (!settings.myCallsign) {
       return { ok: false, error: 'Set your callsign in Settings first — JS8 transmissions carry it.' };
     }
     try {
       startJtcat('JS8');
+      startJs8AudioFeed();
       return { ok: !!js8Engine() };
     } catch (err) {
       return { ok: false, error: String((err && err.message) || err) };
@@ -24662,6 +24675,7 @@ app.whenReady().then(() => {
     if (!js8Engine()) return { ok: true, already: true };
     js8SetHeartbeat(false);
     stopJtcat();
+    stopJs8AudioFeed();
     js8PushStatus();
     return { ok: true };
   });

--- a/preload.js
+++ b/preload.js
@@ -468,6 +468,8 @@ contextBridge.exposeInMainWorld('api', {
   onJtcatTuneAudioStop: (cb) => ipcRenderer.on('jtcat-tune-audio-stop', () => cb()),
   onJtcatStartForRemote: (cb) => ipcRenderer.on('jtcat-start-for-remote', () => cb()),
   onJtcatStopForRemote: (cb) => ipcRenderer.on('jtcat-stop-for-remote', () => cb()),
+  onJtcatStartForJs8: (cb) => ipcRenderer.on('jtcat-start-for-js8', () => cb()),
+  onJtcatStopForJs8: (cb) => ipcRenderer.on('jtcat-stop-for-js8', () => cb()),
   // ECHOCAT FT8 takeover closed the JTCAT popout — surface a toast in the
   // main window so the desktop operator isn't left with a silent vanish.
   onJtcatTakeoverNotice: (cb) => ipcRenderer.on('jtcat-takeover-notice', (_e, data) => cb(data)),

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -24940,6 +24940,7 @@ var jtcatRemoteActive = false; // true when phone is driving JTCAT
 var jtcatQuietFreq = 1500;     // auto-detected quiet TX frequency (Hz)
 var jtcatQuietFreqFrame = 0;   // frame counter for throttling quiet freq updates
 var jtcatSpectrumFrame = 0;    // frame counter for throttling spectrum IPC to ~10fps
+var jtcatJs8AudioActive = false; // true when native JS8 owns the shared JTCAT audio feeder
 
 // --- SmartSDR Direct: synthetic JTCAT audio stream ---
 // On "SmartSDR Direct" the JTCAT audio doesn't come from a Windows DAX
@@ -25216,7 +25217,7 @@ async function startJtcatAudio() {
         console.warn('[JTCAT] Audio track ended (device disconnected?) — restarting capture in 2s');
         if (window.api.jtcatLog) window.api.jtcatLog('[JTCAT] Audio track ended (device disconnected?) — restarting capture in 2s');
         setTimeout(function() {
-          if (jtcatRunning || jtcatRemoteActive) {
+          if (jtcatRunning || jtcatRemoteActive || jtcatJs8AudioActive) {
             stopJtcatAudio();
             startJtcatAudio();
           }
@@ -25418,7 +25419,7 @@ function stopJtcatAudio() {
 
 // Restart JTCAT audio after ECHOCAT releases the shared audio device
 window.api.onRestartJtcatAudio(() => {
-  if (jtcatRunning && !jtcatRemoteActive && !jtcatPopoutOpen) {
+  if ((jtcatRunning || jtcatJs8AudioActive) && !jtcatRemoteActive && !jtcatPopoutOpen) {
     console.log('[JTCAT] Restarting audio after ECHOCAT teardown');
     stopJtcatAudio();
     startJtcatAudio();
@@ -25446,7 +25447,7 @@ function stopJtcatView() {
   // If the phone is driving JTCAT, keep audio capture and engine running
   if (!jtcatRemoteActive) {
     window.api.jtcatStop();
-    stopJtcatAudio();
+    if (!jtcatJs8AudioActive) stopJtcatAudio();
   }
   if (jtcatCountdownTimer) {
     clearInterval(jtcatCountdownTimer);
@@ -27064,8 +27065,22 @@ window.api.onJtcatStopForRemote(function() {
   console.log('[JTCAT] Remote requested audio stop');
   jtcatRemoteActive = false;
   // Only stop audio if the desktop JTCAT view isn't active
-  if (!jtcatRunning) stopJtcatAudio();
+  if (!jtcatRunning && !jtcatJs8AudioActive) stopJtcatAudio();
 });
+if (window.api.onJtcatStartForJs8) {
+  window.api.onJtcatStartForJs8(function() {
+    console.log('[JTCAT] JS8 requested audio start');
+    jtcatJs8AudioActive = true;
+    if (!jtcatPopoutOpen) startJtcatAudio();
+  });
+}
+if (window.api.onJtcatStopForJs8) {
+  window.api.onJtcatStopForJs8(function() {
+    console.log('[JTCAT] JS8 requested audio stop');
+    jtcatJs8AudioActive = false;
+    if (!jtcatRunning && !jtcatRemoteActive) stopJtcatAudio();
+  });
+}
 // ECHOCAT FT8 takeover closed the JTCAT popout — tell the desktop operator
 // (the close is otherwise silent from this side; K3SBP 2026-07-17).
 if (window.api.onJtcatTakeoverNotice) {

--- a/test/js8call-main-wiring-test.js
+++ b/test/js8call-main-wiring-test.js
@@ -22,6 +22,8 @@ const path = require('path');
 const assert = require('assert');
 
 const RAW = fs.readFileSync(path.join(__dirname, '..', 'main.js'), 'utf8');
+const PRELOAD = fs.readFileSync(path.join(__dirname, '..', 'preload.js'), 'utf8');
+const RENDERER = fs.readFileSync(path.join(__dirname, '..', 'renderer', 'app.js'), 'utf8');
 
 /** Comments and string literals blanked to spaces, byte offsets preserved. */
 function blankNonCode(src) {
@@ -264,6 +266,16 @@ test('JS8 starts and stops the shared JTCAT audio feeder', () => {
     'desktop JS8 Start must start both the engine and the audio feeder');
   assert.ok(/remoteServer\.on\('js8-start'[\s\S]*startJtcat\('JS8'\); startJs8AudioFeed\(\)/.test(RAW),
     'remote JS8 Start must start both the engine and the audio feeder');
+  assert.ok(PRELOAD.includes("onJtcatStartForJs8") && PRELOAD.includes("jtcat-start-for-js8"),
+    'preload must expose the JS8 audio-start request to the desktop renderer');
+  assert.ok(PRELOAD.includes("onJtcatStopForJs8") && PRELOAD.includes("jtcat-stop-for-js8"),
+    'preload must expose the JS8 audio-stop request to the desktop renderer');
+  assert.ok(RENDERER.includes('jtcatJs8AudioActive'),
+    'renderer must track JS8 ownership separately from desktop/remote JTCAT');
+  assert.ok(/onJtcatStartForJs8[\s\S]*jtcatJs8AudioActive\s*=\s*true[\s\S]*startJtcatAudio\(\)/.test(RENDERER),
+    'renderer must start the shared audio capture when JS8 asks for it');
+  assert.ok(/onJtcatStopForJs8[\s\S]*jtcatJs8AudioActive\s*=\s*false[\s\S]*stopJtcatAudio\(\)/.test(RENDERER),
+    'renderer must stop only JS8-owned audio when JS8 releases it');
 });
 
 test('HB ACK auto-reply is guarded and session-only', () => {

--- a/test/js8call-main-wiring-test.js
+++ b/test/js8call-main-wiring-test.js
@@ -253,6 +253,19 @@ test('opening the JS8 window auto-starts it; closing stops it', () => {
 
 // ── HB ACK auto-reply is attended + guarded (it is automatic TX) ─────────────
 
+test('JS8 starts and stops the shared JTCAT audio feeder', () => {
+  assert.ok(RAW.includes('function startJs8AudioFeed()'),
+    'JS8 needs its own audio-feeder request, not just a running engine');
+  assert.ok(RAW.includes("webContents.send('jtcat-start-for-js8')"),
+    'JS8 start must ask the desktop renderer to start JTCAT audio capture');
+  assert.ok(RAW.includes("webContents.send('jtcat-stop-for-js8')"),
+    'JS8 stop must release the JS8-owned audio capture');
+  assert.ok(/ipcMain\.handle\('js8-start'[\s\S]*startJtcat\('JS8'\)[\s\S]*startJs8AudioFeed\(\)/.test(RAW),
+    'desktop JS8 Start must start both the engine and the audio feeder');
+  assert.ok(/remoteServer\.on\('js8-start'[\s\S]*startJtcat\('JS8'\); startJs8AudioFeed\(\)/.test(RAW),
+    'remote JS8 Start must start both the engine and the audio feeder');
+});
+
 test('HB ACK auto-reply is guarded and session-only', () => {
   const body = fnBody('js8MaybeAckHeartbeat');
   // Casey 2026-08-10: HB ACK replies until turned OFF — response-to-


### PR DESCRIPTION
## Summary

Fixes native JS8 receive audio startup so JS8 can decode when opened directly, without requiring the JTCAT/FT8 window to be opened first.

## Problem

During testing, JS8 would only reliably show waterfall/decodes if JTCAT/FT8 had already been opened. If JS8 was opened by itself, the JS8 engine could be running, but the shared JTCAT audio capture path was not started for JS8.

## Changes

- Adds JS8-owned audio start/stop signaling from the main process to the desktop renderer.
- Starts the shared JTCAT audio capture when native JS8 starts.
- Stops JS8-owned audio capture when JS8 stops.
- Keeps JS8 audio ownership separate from normal JTCAT/FT8 state so closing JTCAT does not accidentally stop JS8 receive audio.

## Validation

Local checks:

- `node --check main.js`
- `node --check renderer/app.js`
- `node --check preload.js`
- `node test/js8call-main-wiring-test.js`
- `node test/js8-qso-test.js`

Real-radio testing:

- Opened POTACAT fresh.
- Opened JS8 directly without opening JTCAT/FT8 first.
- JS8 waterfall started.
- JS8 decoded live signals.

## Note

On my Windows 10 test laptop using Visual Studio 2019 Build Tools, I also hit a separate native JS8 build compatibility issue in the vendored JS8 C++ source. I have a small compatibility patch for that if needed, but I did not include it here because it may not affect your release build environment and this PR is intentionally limited to the JS8 audio startup fix.