### PR TITLE
fix: recognize FA replies after serial startup noise

### DIFF
--- a/lib/cat.js
+++ b/lib/cat.js
@@ -493,8 +493,11 @@ class CatClient extends EventEmitter {
         }
         this._rejectStreak = 0;
       }
-      if (msg.startsWith('FA')) {
-        const faPayload = msg.slice(2);
+      // A radio can emit an unterminated startup banner before its first CAT
+      // reply. Find a complete FA response even when that prefix shares it.
+      const faMatch = msg.match(/FA(\d{9,11})$/);
+      if (faMatch) {
+        const faPayload = faMatch[1];
         if (faPayload.length >= 9) {
           const wasDetected = this._faDigitsDetected;
           this._faDigits = faPayload.length;

--- a/main.js
+++ b/main.js
@@ -30390,7 +30390,9 @@ app.whenReady().then(() => {
         if (!settled) {
           settled = true;
           try { port.close(); } catch { /* ignore */ }
-          const hint = allData ? `Got data but no FA response: ${allData.slice(0, 120)}` : 'No response from radio. Check baud rate and cable.';
+          const hint = allData
+            ? `Received data but no valid FA frequency response: ${JSON.stringify(allData.slice(0, 120))}. Check the radio's CAT baud rate and serial settings.`
+            : 'No response from radio. Check baud rate and cable.';
           resolve({ success: false, error: hint });
         }
       }, 5000);
@@ -30409,21 +30411,16 @@ app.whenReady().then(() => {
         allData += text;
         buf += text;
         console.log('[serial-cat-test] rx:', JSON.stringify(text));
-        // Scan for any FA response in the stream (skip startup banners etc.)
-        let semi;
-        while ((semi = buf.indexOf(';')) !== -1) {
-          const msg = buf.slice(0, semi);
-          buf = buf.slice(semi + 1);
-          if (msg.startsWith('FA') && !settled) {
-            settled = true;
-            clearTimeout(timeout);
-            try { port.close(); } catch { /* ignore */ }
-            const hz = parseInt(msg.slice(2), 10);
-            const freqMHz = (hz / 1e6).toFixed(6);
-            resolve({ success: true, frequency: freqMHz });
-            return;
-          }
-        }
+        // A startup banner may not be semicolon-terminated, so scan the whole
+        // stream instead of assuming FA starts a delimited message.
+        const faMatch = /FA(\d{9,11});/.exec(buf);
+        if (!faMatch || settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        try { port.close(); } catch { /* ignore */ }
+        const hz = parseInt(faMatch[1], 10);
+        const freqMHz = (hz / 1e6).toFixed(6);
+        resolve({ success: true, frequency: freqMHz });
       });
 
       port.on('error', (err) => {

--- a/test/rig-test.js
+++ b/test/rig-test.js
@@ -10,6 +10,7 @@ const assert = require('assert');
 const { KenwoodCodec, expand, ssbSideband } = require('../lib/codecs/kenwood-codec');
 const { RigctldCodec } = require('../lib/codecs/rigctld-codec');
 const { CivCodec } = require('../lib/codecs/civ-codec');
+const { CatClient } = require('../lib/cat');
 
 let passed = 0;
 let failed = 0;
@@ -172,6 +173,14 @@ test('Yaesu parse FA response (9 digits)', () => {
   let freq = 0;
   codec.on('frequency', (hz) => { freq = hz; });
   codec.onData('FA014074000;');
+  assert.strictEqual(freq, 14074000);
+});
+
+test('CatClient parses FA response after unterminated startup data', () => {
+  const client = new CatClient();
+  let freq = 0;
+  client.on('frequency', (hz) => { freq = hz; });
+  client._onData(']bFA014074000;');
   assert.strictEqual(freq, 14074000);
 });
 


### PR DESCRIPTION
Serial CAT test traffic can contain an unterminated startup prefix before a valid frequency reply, causing POTACAT to report a false missing-FA failure.

Recognize complete 9- or 11-digit `FA...;` responses anywhere in the received stream, preserve normal frequency parsing after startup noise, and clarify the diagnostic when bytes are received but no valid CAT response is found.